### PR TITLE
lab base update - rev 2.6.5

### DIFF
--- a/.devcontainer/techlib-mlag-fabric/devcontainer.json
+++ b/.devcontainer/techlib-mlag-fabric/devcontainer.json
@@ -24,5 +24,6 @@
     "postCreateCommand": "/bin/entrypoint",
     "workspaceMount": "source=${localWorkspaceFolder}/labs/${containerWorkspaceFolder},target=/${containerWorkspaceFolder},type=bind",
     "workspaceFolder": "/techlib-mlag-fabric",
-    "containerUser": "avd"
+    "containerUser": "avd",
+    "runArgs": ["--env-file","${localWorkspaceFolder}/labs/${containerWorkspaceFolder}/.vscode/lab_vars.public.env"]
 }

--- a/.devcontainer/techlib-mlag-fabric/devcontainer.json
+++ b/.devcontainer/techlib-mlag-fabric/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "ghcr.io/${localEnv:GITHUB_REPOSITORY}/lab-base:python3.12-avd-v5.7.3-clab0.74.0-rev2.6.4",
+    "image": "ghcr.io/${localEnv:GITHUB_REPOSITORY}/lab-base:python3.12-avd-v5.7.3-clab0.74.3-rev2.6.5",
     // containerEnv set the variables applied to entire container
     "containerEnv": {
         "ARISTA_TOKEN": "${localEnv:ARTOKEN}",

--- a/.github/workflows/container_build_parent_matrix.yml
+++ b/.github/workflows/container_build_parent_matrix.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         from_image: ["ghcr.io/aristanetworks/avd/universal"]
         from_variant: ["python3.11-avd-v5.7.3", "python3.12-avd-v5.7.3"]
-        clab_version: ["0.74.0"]
+        clab_version: ["0.74.3"]
         user_id: ["1000", "1009"]
         include:
           - user_id: "1000"
@@ -96,4 +96,8 @@ jobs:
       # - AVD 5.7.3
       # 2.6.4
       # - ContainerLab 0.74.0
-      container_revision: "2.6.4"
+      # 2.6.5
+      # - ContainerLab 0.74.3
+      # - entrypoint.sh updated to load env variables from lab_vars.public.env when lab starts
+      # - code-server v4.115.0
+      container_revision: "2.6.5"

--- a/.github/workflows/container_build_parent_matrix.yml
+++ b/.github/workflows/container_build_parent_matrix.yml
@@ -98,6 +98,5 @@ jobs:
       # - ContainerLab 0.74.0
       # 2.6.5
       # - ContainerLab 0.74.3
-      # - entrypoint.sh updated to load env variables from lab_vars.public.env when lab starts
       # - code-server v4.115.0
       container_revision: "2.6.5"

--- a/containers/lab-base/.devcontainer/Dockerfile
+++ b/containers/lab-base/.devcontainer/Dockerfile
@@ -50,7 +50,7 @@ RUN bash -c "$(curl -sL https://get.containerlab.dev)" -- -v ${CLAB_VERSION} \
     && pip install --user passlib
 
 # install coder and extensions
-RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version="4.106.3" \
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version="4.115.0" \
     && code-server --install-extension srl-labs.vscode-containerlab --force \
     && code-server --install-extension tuxtina.json2yaml --force \
     && code-server --install-extension yzhang.markdown-all-in-one --force

--- a/containers/lab-base/.devcontainer/entrypoint.sh
+++ b/containers/lab-base/.devcontainer/entrypoint.sh
@@ -2,6 +2,17 @@
 
 set +e
 
+# Load per-lab variables if present. This sources a KEY=value file from the
+# lab's .vscode directory into entrypoint.sh's environment, so every downstream
+# process (code-server, its tasks, its terminals, and `make start`) inherits it.
+# Gated on file existence — labs without this file are unaffected.
+LAB_VARS_FILE="${CONTAINERWSF}/.vscode/lab_vars.public.env"
+if [ -f "${LAB_VARS_FILE}" ]; then
+    set -a           # auto-export everything sourced
+    . "${LAB_VARS_FILE}"
+    set +a
+fi
+
 # do not use moby script when docker is already available
 # calling moby script on top of working docker deployment can break it in some cases (for ex.: Codespaces)
 if ! ${CODESPACES:-false} && ! ${REMOTE_CONTAINERS:-false}; then

--- a/containers/lab-base/.devcontainer/entrypoint.sh
+++ b/containers/lab-base/.devcontainer/entrypoint.sh
@@ -2,17 +2,6 @@
 
 set +e
 
-# Load per-lab variables if present. This sources a KEY=value file from the
-# lab's .vscode directory into entrypoint.sh's environment, so every downstream
-# process (code-server, its tasks, its terminals, and `make start`) inherits it.
-# Gated on file existence — labs without this file are unaffected.
-LAB_VARS_FILE="${CONTAINERWSF}/.vscode/lab_vars.public.env"
-if [ -f "${LAB_VARS_FILE}" ]; then
-    set -a           # auto-export everything sourced
-    . "${LAB_VARS_FILE}"
-    set +a
-fi
-
 # do not use moby script when docker is already available
 # calling moby script on top of working docker deployment can break it in some cases (for ex.: Codespaces)
 if ! ${CODESPACES:-false} && ! ${REMOTE_CONTAINERS:-false}; then

--- a/labs/techlib-mlag-fabric/.vscode/tasks.json
+++ b/labs/techlib-mlag-fabric/.vscode/tasks.json
@@ -1,16 +1,16 @@
 {
     "version": "2.0.0",
-    // "tasks": [
-    //     {
-    //         "label": "init_lab",
-    //         "command": "lab_start_task.py",
-    //         "type": "shell",
-    //         "presentation": {
-    //             "reveal": "always"
-    //         },
-    //         "runOptions": {
-    //             "runOn": "folderOpen"
-    //         }
-    //     }
-    // ]
+    "tasks": [
+        {
+            "label": "init_lab",
+            "command": "lab_start_task.py",
+            "type": "shell",
+            "presentation": {
+                "reveal": "always"
+            },
+            "runOptions": {
+                "runOn": "folderOpen"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
## Change Summary

- Update `lab-base` container to revision 2.6.5
  - ContainerLab 0.74.3
  - code-server 4.115.0

- Update `techlib-mlag-fabric` lab `.devcontainer`
  -  Include `runArgs` parameter
  - Use lab-base 2.6.5 image

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from the upstream `main` branch
