### PR TITLE
Updated the BGP and Added the EVPN Dashboards

### DIFF
--- a/labs/gnmic-prometheus-grafana/clab/gnmic.yml
+++ b/labs/gnmic-prometheus-grafana/clab/gnmic.yml
@@ -149,6 +149,7 @@ outputs:
     debug: false
     event-processors:
       - extract-vlan-id
+      - drop-gr
       - trim-prefixes
       - bounce-map
       - eos-version
@@ -201,3 +202,9 @@ processors:
             apply-on: "value"
             old: "DOWN"
             new: "0"
+  # Need this processor, otherwise trim-prefixes will cause name collision and overwrite the pfxRcd
+  # metrics to 0
+  drop-gr:
+    event-delete:
+      value-names:
+        - ".*graceful-restart.*"

--- a/labs/gnmic-prometheus-grafana/clab/grafana/provisioning/dashboards/evpn-telemetry.json
+++ b/labs/gnmic-prometheus-grafana/clab/grafana/provisioning/dashboards/evpn-telemetry.json
@@ -1,0 +1,1186 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 6,
+    "links": [],
+    "panels": [
+      {
+        "datasource": {
+          "default": false,
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "color-text"
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true,
+          "sortBy": [
+            {
+              "desc": false,
+              "displayName": "Hostname"
+            }
+          ]
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "gnmic_bgp_neighbors_peer_as{job=\"gnmic\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"}",
+            "format": "table",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": false,
+            "refId": "A",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "gnmic_bgp_neighbors_session_state{job=\"gnmic\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"}",
+            "format": "table",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": false,
+            "refId": "B",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "gnmic_bgp_neighbors_installed{job=\"gnmic\", afi_safi_afi_safi_name=\"L2VPN_EVPN\", source=~\"$Device\"}",
+            "format": "table",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": false,
+            "refId": "C",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "gnmic_bgp_neighbors_received{job=\"gnmic\", afi_safi_afi_safi_name=\"L2VPN_EVPN\", source=~\"$Device\"}",
+            "format": "table",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": false,
+            "refId": "D",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "gnmic_bgp_neighbors_established_transitions{job=\"gnmic\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"}",
+            "format": "table",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": false,
+            "refId": "E",
+            "useBackend": false
+          }
+        ],
+        "title": "EVPN BGP Summary",
+        "transformations": [
+          {
+            "id": "seriesToColumns",
+            "options": {
+              "byField": "neighbor_neighbor_address"
+            }
+          },
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time 1": true,
+                "Time 2": true,
+                "Time 3": true,
+                "Time 4": true,
+                "Time 5": true,
+                "__name__": true,
+                "__name__ 1": true,
+                "__name__ 2": true,
+                "__name__ 3": true,
+                "__name__ 4": true,
+                "__name__ 5": true,
+                "afi_safi_afi_safi_name": true,
+                "afi_safi_afi_safi_name 1": true,
+                "afi_safi_afi_safi_name 2": true,
+                "afi_safi_afi_safi_name 3": true,
+                "afi_safi_afi_safi_name 4": true,
+                "afi_safi_afi_safi_name 5": true,
+                "instance": true,
+                "instance 1": true,
+                "instance 2": true,
+                "instance 3": true,
+                "instance 4": true,
+                "instance 5": true,
+                "job": true,
+                "job 1": true,
+                "job 2": true,
+                "job 3": true,
+                "job 4": true,
+                "job 5": true,
+                "network_instance_name 2": true,
+                "network_instance_name 3": true,
+                "network_instance_name 4": true,
+                "network_instance_name 5": true,
+                "protocol_identifier": true,
+                "protocol_identifier 1": true,
+                "protocol_identifier 2": true,
+                "protocol_identifier 3": true,
+                "protocol_identifier 4": true,
+                "protocol_identifier 5": true,
+                "protocol_name": true,
+                "protocol_name 1": true,
+                "protocol_name 2": true,
+                "protocol_name 3": true,
+                "protocol_name 4": true,
+                "protocol_name 5": true,
+                "source 2": true,
+                "source 3": true,
+                "source 4": true,
+                "source 5": true,
+                "subscription_name": true,
+                "subscription_name 1": true,
+                "subscription_name 2": true,
+                "subscription_name 3": true,
+                "subscription_name 4": true,
+                "subscription_name 5": true,
+                "Value #B": true
+              },
+              "includeByName": {},
+              "indexByName": {
+                "source 1": 0,
+                "neighbor_neighbor_address": 1,
+                "network_instance_name 1": 2,
+                "Value #A": 3,
+                "session_state": 4,
+                "Value #C": 5,
+                "Value #D": 6,
+                "Value #E": 7
+              },
+              "renameByName": {
+                "Value #A": "Peer AS",
+                "Value #C": "EVPN Pfx Installed",
+                "Value #D": "EVPN Pfx Received",
+                "Value #E": "Est. Transitions",
+                "neighbor_neighbor_address": "Neighbor IP",
+                "network_instance_name": "VRF",
+                "network_instance_name 1": "VRF",
+                "session_state": "Session State",
+                "source 1": "Hostname"
+              }
+            }
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "datasource": {
+          "default": false,
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": []
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "ESTABLISHED"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "IDLE"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "red",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "ACTIVE"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "yellow",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "CONNECT"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "orange",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 6,
+          "x": 12,
+          "y": 0
+        },
+        "id": 2,
+        "options": {
+          "displayLabels": [
+            "value",
+            "percent"
+          ],
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true,
+            "values": [
+              "value",
+              "percent"
+            ]
+          },
+          "pieType": "donut",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "count by (session_state) (gnmic_bgp_neighbors_session_state{job=\"gnmic\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "{{session_state}}",
+            "range": false,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "EVPN Session States",
+        "type": "piechart"
+      },
+      {
+        "datasource": {
+          "default": false,
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 3,
+          "x": 18,
+          "y": 0
+        },
+        "id": 3,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "count(gnmic_bgp_neighbors_session_state{job=\"gnmic\", neighbor_neighbor_address=~\"192.168.255.*\", session_state=\"ESTABLISHED\", source=~\"$Device\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "Established",
+            "range": false,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Established EVPN Peers",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "default": false,
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 3,
+          "x": 21,
+          "y": 0
+        },
+        "id": 4,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "count(gnmic_bgp_neighbors_session_state{job=\"gnmic\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "Total",
+            "range": false,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Total EVPN Peers",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "default": false,
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 18,
+          "y": 6
+        },
+        "id": 5,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "sum(gnmic_bgp_neighbors_installed{job=\"gnmic\", afi_safi_afi_safi_name=\"L2VPN_EVPN\", source=~\"$Device\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "Total Installed",
+            "range": false,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Total EVPN Routes Installed",
+        "type": "stat"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 12
+        },
+        "id": 10,
+        "panels": [
+          {
+            "datasource": {
+              "default": false,
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 50
+                    },
+                    {
+                      "color": "red",
+                      "value": 100
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 10,
+              "w": 12,
+              "x": 0,
+              "y": 13
+            },
+            "id": 11,
+            "options": {
+              "displayMode": "gradient",
+              "maxVizHeight": 300,
+              "minVizHeight": 16,
+              "minVizWidth": 8,
+              "namePlacement": "auto",
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "sizing": "auto",
+              "valueMode": "color"
+            },
+            "pluginVersion": "11.2.0",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "gnmic_bgp_neighbors_installed{job=\"gnmic\", afi_safi_afi_safi_name=\"L2VPN_EVPN\", source=~\"$Device\"}",
+                "format": "time_series",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "instant": true,
+                "legendFormat": "{{source}} -> {{neighbor_neighbor_address}}",
+                "range": false,
+                "refId": "A",
+                "useBackend": false
+              }
+            ],
+            "title": "EVPN Prefixes Installed per Neighbor",
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "default": false,
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "Prefixes",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "stepAfter",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 10,
+              "w": 12,
+              "x": 12,
+              "y": 13
+            },
+            "id": 12,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "expr": "gnmic_bgp_neighbors_installed{job=\"gnmic\", afi_safi_afi_safi_name=\"L2VPN_EVPN\", source=~\"$Device\"}",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "instant": false,
+                "legendFormat": "{{source}} -> {{neighbor_neighbor_address}} (installed)",
+                "range": true,
+                "refId": "A",
+                "useBackend": false
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "expr": "gnmic_bgp_neighbors_received{job=\"gnmic\", afi_safi_afi_safi_name=\"L2VPN_EVPN\", source=~\"$Device\"}",
+                "fullMetaSearch": false,
+                "hide": false,
+                "includeNullMetadata": true,
+                "instant": false,
+                "legendFormat": "{{source}} -> {{neighbor_neighbor_address}} (received)",
+                "range": true,
+                "refId": "B",
+                "useBackend": false
+              }
+            ],
+            "title": "EVPN Prefixes Over Time",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "default": false,
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "Rejected Prefixes",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "stepAfter",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 23
+            },
+            "id": 13,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "expr": "gnmic_bgp_neighbors_received{job=\"gnmic\", afi_safi_afi_safi_name=\"L2VPN_EVPN\", source=~\"$Device\"} - gnmic_bgp_neighbors_installed{job=\"gnmic\", afi_safi_afi_safi_name=\"L2VPN_EVPN\", source=~\"$Device\"}",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "instant": false,
+                "legendFormat": "{{source}} -> {{neighbor_neighbor_address}} (rejected)",
+                "range": true,
+                "refId": "A",
+                "useBackend": false
+              }
+            ],
+            "title": "EVPN Received vs Installed Delta (Rejected Routes)",
+            "type": "timeseries"
+          }
+        ],
+        "title": "EVPN Route Counts",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 13
+        },
+        "id": 20,
+        "panels": [
+          {
+            "datasource": {
+              "default": false,
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 3
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 10,
+              "w": 12,
+              "x": 0,
+              "y": 14
+            },
+            "id": 21,
+            "options": {
+              "displayMode": "gradient",
+              "maxVizHeight": 300,
+              "minVizHeight": 16,
+              "minVizWidth": 8,
+              "namePlacement": "auto",
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "sizing": "auto",
+              "valueMode": "color"
+            },
+            "pluginVersion": "11.2.0",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "gnmic_bgp_neighbors_established_transitions{job=\"gnmic\", source=~\"$Device\", neighbor_neighbor_address=~\"192.168.255.*\"}",
+                "format": "time_series",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "instant": true,
+                "legendFormat": "{{source}} -> {{neighbor_neighbor_address}}",
+                "range": false,
+                "refId": "A",
+                "useBackend": false
+              }
+            ],
+            "title": "EVPN Overlay Peer Flap Count",
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "default": false,
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "Transitions",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "stepAfter",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 10,
+              "w": 12,
+              "x": 12,
+              "y": 14
+            },
+            "id": 22,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "expr": "gnmic_bgp_neighbors_established_transitions{job=\"gnmic\", source=~\"$Device\", neighbor_neighbor_address=~\"192.168.255.*\"}",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "instant": false,
+                "legendFormat": "{{source}} -> {{neighbor_neighbor_address}}",
+                "range": true,
+                "refId": "A",
+                "useBackend": false
+              }
+            ],
+            "title": "EVPN Overlay Peer Flaps Over Time",
+            "type": "timeseries"
+          }
+        ],
+        "title": "EVPN Stability",
+        "type": "row"
+      }
+    ],
+    "schemaVersion": 39,
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "definition": "label_values(gnmic_bgp_neighbors_installed{afi_safi_afi_safi_name=\"L2VPN_EVPN\"}, source)",
+          "hide": 0,
+          "includeAll": true,
+          "multi": true,
+          "name": "Device",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values(gnmic_bgp_neighbors_installed{afi_safi_afi_safi_name=\"L2VPN_EVPN\"}, source)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "EVPN Telemetry",
+    "uid": "evpn-telemetry-001",
+    "version": 1,
+    "weekStart": ""
+  }

--- a/labs/gnmic-prometheus-grafana/clab/grafana/provisioning/dashboards/evpn-telemetry.json
+++ b/labs/gnmic-prometheus-grafana/clab/grafana/provisioning/dashboards/evpn-telemetry.json
@@ -87,7 +87,7 @@
             "disableTextWrap": false,
             "editorMode": "code",
             "exemplar": false,
-            "expr": "gnmic_bgp_neighbors_peer_as{job=\"gnmic\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"}",
+            "expr": "label_join(gnmic_bgp_neighbors_peer_as{job=\"gnmic\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"}, \"join_key\", \"-\", \"source\", \"neighbor_neighbor_address\")",
             "format": "table",
             "fullMetaSearch": false,
             "includeNullMetadata": true,
@@ -105,7 +105,7 @@
             "disableTextWrap": false,
             "editorMode": "code",
             "exemplar": false,
-            "expr": "gnmic_bgp_neighbors_session_state{job=\"gnmic\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"}",
+            "expr": "label_join(gnmic_bgp_neighbors_session_state{job=\"gnmic\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"}, \"join_key\", \"-\", \"source\", \"neighbor_neighbor_address\")",
             "format": "table",
             "fullMetaSearch": false,
             "hide": false,
@@ -124,7 +124,7 @@
             "disableTextWrap": false,
             "editorMode": "code",
             "exemplar": false,
-            "expr": "gnmic_bgp_neighbors_installed{job=\"gnmic\", afi_safi_afi_safi_name=\"L2VPN_EVPN\", source=~\"$Device\"}",
+            "expr": "label_join(gnmic_bgp_neighbors_installed{job=\"gnmic\", afi_safi_afi_safi_name=\"L2VPN_EVPN\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"}, \"join_key\", \"-\", \"source\", \"neighbor_neighbor_address\")",
             "format": "table",
             "fullMetaSearch": false,
             "hide": false,
@@ -143,7 +143,7 @@
             "disableTextWrap": false,
             "editorMode": "code",
             "exemplar": false,
-            "expr": "gnmic_bgp_neighbors_received{job=\"gnmic\", afi_safi_afi_safi_name=\"L2VPN_EVPN\", source=~\"$Device\"}",
+            "expr": "label_join(gnmic_bgp_neighbors_received{job=\"gnmic\", afi_safi_afi_safi_name=\"L2VPN_EVPN\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"}, \"join_key\", \"-\", \"source\", \"neighbor_neighbor_address\")",
             "format": "table",
             "fullMetaSearch": false,
             "hide": false,
@@ -162,7 +162,7 @@
             "disableTextWrap": false,
             "editorMode": "code",
             "exemplar": false,
-            "expr": "gnmic_bgp_neighbors_established_transitions{job=\"gnmic\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"}",
+            "expr": "label_join(gnmic_bgp_neighbors_established_transitions{job=\"gnmic\", neighbor_neighbor_address=~\"192.168.255.*\", source=~\"$Device\"}, \"join_key\", \"-\", \"source\", \"neighbor_neighbor_address\")",
             "format": "table",
             "fullMetaSearch": false,
             "hide": false,
@@ -179,7 +179,7 @@
           {
             "id": "seriesToColumns",
             "options": {
-              "byField": "neighbor_neighbor_address"
+              "byField": "join_key"
             }
           },
           {
@@ -215,6 +215,11 @@
                 "job 3": true,
                 "job 4": true,
                 "job 5": true,
+                "join_key": true,
+                "neighbor_neighbor_address 2": true,
+                "neighbor_neighbor_address 3": true,
+                "neighbor_neighbor_address 4": true,
+                "neighbor_neighbor_address 5": true,
                 "network_instance_name 2": true,
                 "network_instance_name 3": true,
                 "network_instance_name 4": true,
@@ -246,7 +251,7 @@
               "includeByName": {},
               "indexByName": {
                 "source 1": 0,
-                "neighbor_neighbor_address": 1,
+                "neighbor_neighbor_address 1": 1,
                 "network_instance_name 1": 2,
                 "Value #A": 3,
                 "session_state": 4,
@@ -259,8 +264,7 @@
                 "Value #C": "EVPN Pfx Installed",
                 "Value #D": "EVPN Pfx Received",
                 "Value #E": "Est. Transitions",
-                "neighbor_neighbor_address": "Neighbor IP",
-                "network_instance_name": "VRF",
+                "neighbor_neighbor_address 1": "Neighbor IP",
                 "network_instance_name 1": "VRF",
                 "session_state": "Session State",
                 "source 1": "Hostname"
@@ -1154,7 +1158,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "definition": "label_values(gnmic_bgp_neighbors_installed{afi_safi_afi_safi_name=\"L2VPN_EVPN\"}, source)",
+          "definition": "label_values(gnmic_bgp_neighbors_session_state{neighbor_neighbor_address=~\"192.168.255.*\"}, source)",
           "hide": 0,
           "includeAll": true,
           "multi": true,
@@ -1162,7 +1166,7 @@
           "options": [],
           "query": {
             "qryType": 1,
-            "query": "label_values(gnmic_bgp_neighbors_installed{afi_safi_afi_safi_name=\"L2VPN_EVPN\"}, source)",
+            "query": "label_values(gnmic_bgp_neighbors_session_state{neighbor_neighbor_address=~\"192.168.255.*\"}, source)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,

--- a/labs/gnmic-prometheus-grafana/clab/grafana/provisioning/dashboards/l3-telemetry.json
+++ b/labs/gnmic-prometheus-grafana/clab/grafana/provisioning/dashboards/l3-telemetry.json
@@ -30,26 +30,150 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "mode": "thresholds"
+              "mode": "palette-classic"
             },
             "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "color-text"
-              },
-              "inspect": false
-            },
-            "mappings": [
-              {
-                "options": {
-                  "0": {
-                    "color": "dark-red",
-                    "index": 0
-                  }
-                },
-                "type": "value"
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
               }
+            },
+            "mappings": []
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "ESTABLISHED"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "IDLE"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "red",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "ACTIVE"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "yellow",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "CONNECT"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "orange",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 6,
+          "x": 0,
+          "y": 0
+        },
+        "id": 3,
+        "options": {
+          "displayLabels": [
+            "value",
+            "percent"
+          ],
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true,
+            "values": [
+              "value",
+              "percent"
+            ]
+          },
+          "pieType": "donut",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
             ],
+            "fields": "",
+            "values": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "count by (session_state) (gnmic_bgp_neighbors_session_state{job=\"gnmic\", source=~\"$Device\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "{{session_state}}",
+            "range": false,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "BGP Session States",
+        "type": "piechart"
+      },
+      {
+        "datasource": {
+          "default": false,
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
             "thresholds": {
               "mode": "absolute",
               "steps": [
@@ -63,12 +187,244 @@
           "overrides": []
         },
         "gridPos": {
-          "h": 26,
-          "w": 9,
-          "x": 0,
+          "h": 5,
+          "w": 4,
+          "x": 6,
           "y": 0
         },
-        "id": 1,
+        "id": 4,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "count(gnmic_bgp_neighbors_session_state{job=\"gnmic\", session_state=\"ESTABLISHED\", source=~\"$Device\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "Established",
+            "range": false,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Established Peers",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "default": false,
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 4,
+          "x": 6,
+          "y": 5
+        },
+        "id": 5,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "count(gnmic_bgp_neighbors_session_state{job=\"gnmic\", source=~\"$Device\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "Total",
+            "range": false,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Total BGP Peers",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "default": false,
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "orange",
+                  "value": 1
+                },
+                {
+                  "color": "red",
+                  "value": 3
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 14,
+          "x": 10,
+          "y": 0
+        },
+        "id": 6,
+        "options": {
+          "displayMode": "gradient",
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "color"
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "gnmic_bgp_neighbors_established_transitions{job=\"gnmic\", source=~\"$Device\"}",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "{{source}} -> {{neighbor_neighbor_address}}",
+            "range": false,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Established Transitions (Flap Count)",
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "default": false,
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "color-text"
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 24,
+          "x": 0,
+          "y": 10
+        },
+        "id": 7,
         "options": {
           "cellHeight": "sm",
           "footer": {
@@ -83,7 +439,7 @@
           "sortBy": [
             {
               "desc": false,
-              "displayName": "source"
+              "displayName": "Hostname"
             }
           ]
         },
@@ -95,9 +451,9 @@
               "uid": "PBFA97CFB590B2093"
             },
             "disableTextWrap": false,
-            "editorMode": "builder",
+            "editorMode": "code",
             "exemplar": false,
-            "expr": "gnmic_bgp_neighbors_installed{afi_safi_afi_safi_name=\"IPV4_UNICAST\"}",
+            "expr": "gnmic_bgp_neighbors_peer_as{job=\"gnmic\", source=~\"$Device\"}",
             "format": "table",
             "fullMetaSearch": false,
             "includeNullMetadata": true,
@@ -106,54 +462,405 @@
             "range": false,
             "refId": "A",
             "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "gnmic_bgp_neighbors_session_state{job=\"gnmic\", source=~\"$Device\"}",
+            "format": "table",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": false,
+            "refId": "B",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "gnmic_bgp_neighbors_installed{job=\"gnmic\", afi_safi_afi_safi_name=\"IPV4_UNICAST\", source=~\"$Device\"}",
+            "format": "table",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": false,
+            "refId": "C",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "gnmic_bgp_neighbors_established_transitions{job=\"gnmic\", source=~\"$Device\"}",
+            "format": "table",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": false,
+            "refId": "D",
+            "useBackend": false
           }
         ],
-        "title": "BGP IPv4 Unicast Summary",
+        "title": "BGP Neighbors Detail",
         "transformations": [
+          {
+            "id": "seriesToColumns",
+            "options": {
+              "byField": "neighbor_neighbor_address"
+            }
+          },
           {
             "id": "organize",
             "options": {
               "excludeByName": {
-                "Time": true,
+                "Time 1": true,
+                "Time 2": true,
+                "Time 3": true,
+                "Time 4": true,
                 "__name__": true,
+                "__name__ 1": true,
+                "__name__ 2": true,
+                "__name__ 3": true,
+                "__name__ 4": true,
+                "afi_safi_afi_safi_name": true,
+                "afi_safi_afi_safi_name 1": true,
+                "afi_safi_afi_safi_name 2": true,
+                "afi_safi_afi_safi_name 3": true,
                 "instance": true,
+                "instance 1": true,
+                "instance 2": true,
+                "instance 3": true,
+                "instance 4": true,
                 "job": true,
-                "network_instance_name": false,
+                "job 1": true,
+                "job 2": true,
+                "job 3": true,
+                "job 4": true,
+                "network_instance_name 2": true,
+                "network_instance_name 3": true,
+                "network_instance_name 4": true,
                 "protocol_identifier": true,
+                "protocol_identifier 1": true,
+                "protocol_identifier 2": true,
+                "protocol_identifier 3": true,
+                "protocol_identifier 4": true,
                 "protocol_name": true,
-                "subscription_name": true
+                "protocol_name 1": true,
+                "protocol_name 2": true,
+                "protocol_name 3": true,
+                "protocol_name 4": true,
+                "source 2": true,
+                "source 3": true,
+                "source 4": true,
+                "subscription_name": true,
+                "subscription_name 1": true,
+                "subscription_name 2": true,
+                "subscription_name 3": true,
+                "subscription_name 4": true,
+                "Value #B": true
               },
               "includeByName": {},
               "indexByName": {
-                "Time": 1,
-                "Value": 11,
-                "__name__": 2,
-                "afi_safi_afi_safi_name": 3,
-                "instance": 4,
-                "job": 5,
-                "neighbor_neighbor_address": 6,
-                "network_instance_name": 7,
-                "protocol_identifier": 8,
-                "protocol_name": 9,
-                "source": 0,
-                "subscription_name": 10
+                "source 1": 0,
+                "neighbor_neighbor_address": 1,
+                "network_instance_name 1": 2,
+                "Value #A": 3,
+                "session_state": 4,
+                "Value #C": 5,
+                "Value #D": 6
               },
               "renameByName": {
-                "Value": "PfxAcc",
+                "Value #A": "Peer AS",
+                "Value #C": "IPv4 Pfx Installed",
+                "Value #D": "Est. Transitions",
                 "neighbor_neighbor_address": "Neighbor IP",
                 "network_instance_name": "VRF",
-                "source": "Hostname"
+                "network_instance_name 1": "VRF",
+                "session_state": "Session State",
+                "source": "Hostname",
+                "source 1": "Hostname"
               }
             }
           }
         ],
         "type": "table"
+      },
+      {
+        "datasource": {
+          "default": false,
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "stepAfter",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 20
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "gnmic_bgp_neighbors_established_transitions{job=\"gnmic\", source=~\"$Device\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{source}} -> {{neighbor_neighbor_address}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Established Transitions Over Time",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "default": false,
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 20
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "gnmic_bgp_neighbors_installed{job=\"gnmic\", afi_safi_afi_safi_name=\"IPV4_UNICAST\", source=~\"$Device\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{source}} -> {{neighbor_neighbor_address}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "gnmic_bgp_neighbors_received{job=\"gnmic\", afi_safi_afi_safi_name=\"IPV4_UNICAST\", source=~\"$Device\"}",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{source}} -> {{neighbor_neighbor_address}} (received)",
+            "range": true,
+            "refId": "B",
+            "useBackend": false
+          }
+        ],
+        "title": "IPv4 Unicast Prefixes Over Time",
+        "type": "timeseries"
       }
     ],
     "schemaVersion": 39,
     "tags": [],
     "templating": {
-      "list": []
+      "list": [
+        {
+          "current": {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "definition": "label_values(gnmic_bgp_neighbors_session_state, source)",
+          "hide": 0,
+          "includeAll": true,
+          "multi": true,
+          "name": "Device",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values(gnmic_bgp_neighbors_session_state, source)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        }
+      ]
     },
     "time": {
       "from": "now-6h",

--- a/labs/gnmic-prometheus-grafana/clab/grafana/provisioning/dashboards/l3-telemetry.json
+++ b/labs/gnmic-prometheus-grafana/clab/grafana/provisioning/dashboards/l3-telemetry.json
@@ -453,7 +453,7 @@
             "disableTextWrap": false,
             "editorMode": "code",
             "exemplar": false,
-            "expr": "gnmic_bgp_neighbors_peer_as{job=\"gnmic\", source=~\"$Device\"}",
+            "expr": "label_join(gnmic_bgp_neighbors_peer_as{job=\"gnmic\", source=~\"$Device\"}, \"join_key\", \"-\", \"source\", \"neighbor_neighbor_address\")",
             "format": "table",
             "fullMetaSearch": false,
             "includeNullMetadata": true,
@@ -471,7 +471,7 @@
             "disableTextWrap": false,
             "editorMode": "code",
             "exemplar": false,
-            "expr": "gnmic_bgp_neighbors_session_state{job=\"gnmic\", source=~\"$Device\"}",
+            "expr": "label_join(gnmic_bgp_neighbors_session_state{job=\"gnmic\", source=~\"$Device\"}, \"join_key\", \"-\", \"source\", \"neighbor_neighbor_address\")",
             "format": "table",
             "fullMetaSearch": false,
             "hide": false,
@@ -490,7 +490,7 @@
             "disableTextWrap": false,
             "editorMode": "code",
             "exemplar": false,
-            "expr": "gnmic_bgp_neighbors_installed{job=\"gnmic\", afi_safi_afi_safi_name=\"IPV4_UNICAST\", source=~\"$Device\"}",
+            "expr": "label_join(gnmic_bgp_neighbors_installed{job=\"gnmic\", afi_safi_afi_safi_name=\"IPV4_UNICAST\", source=~\"$Device\"}, \"join_key\", \"-\", \"source\", \"neighbor_neighbor_address\")",
             "format": "table",
             "fullMetaSearch": false,
             "hide": false,
@@ -509,7 +509,7 @@
             "disableTextWrap": false,
             "editorMode": "code",
             "exemplar": false,
-            "expr": "gnmic_bgp_neighbors_established_transitions{job=\"gnmic\", source=~\"$Device\"}",
+            "expr": "label_join(gnmic_bgp_neighbors_established_transitions{job=\"gnmic\", source=~\"$Device\"}, \"join_key\", \"-\", \"source\", \"neighbor_neighbor_address\")",
             "format": "table",
             "fullMetaSearch": false,
             "hide": false,
@@ -526,7 +526,7 @@
           {
             "id": "seriesToColumns",
             "options": {
-              "byField": "neighbor_neighbor_address"
+              "byField": "join_key"
             }
           },
           {
@@ -542,10 +542,6 @@
                 "__name__ 2": true,
                 "__name__ 3": true,
                 "__name__ 4": true,
-                "afi_safi_afi_safi_name": true,
-                "afi_safi_afi_safi_name 1": true,
-                "afi_safi_afi_safi_name 2": true,
-                "afi_safi_afi_safi_name 3": true,
                 "instance": true,
                 "instance 1": true,
                 "instance 2": true,
@@ -556,6 +552,10 @@
                 "job 2": true,
                 "job 3": true,
                 "job 4": true,
+                "join_key": true,
+                "neighbor_neighbor_address 2": true,
+                "neighbor_neighbor_address 3": true,
+                "neighbor_neighbor_address 4": true,
                 "network_instance_name 2": true,
                 "network_instance_name 3": true,
                 "network_instance_name 4": true,
@@ -582,22 +582,22 @@
               "includeByName": {},
               "indexByName": {
                 "source 1": 0,
-                "neighbor_neighbor_address": 1,
-                "network_instance_name 1": 2,
-                "Value #A": 3,
-                "session_state": 4,
-                "Value #C": 5,
-                "Value #D": 6
+                "afi_safi_afi_safi_name": 1,
+                "neighbor_neighbor_address 1": 2,
+                "network_instance_name 1": 3,
+                "Value #A": 4,
+                "session_state": 5,
+                "Value #C": 6,
+                "Value #D": 7
               },
               "renameByName": {
                 "Value #A": "Peer AS",
                 "Value #C": "IPv4 Pfx Installed",
                 "Value #D": "Est. Transitions",
-                "neighbor_neighbor_address": "Neighbor IP",
-                "network_instance_name": "VRF",
+                "afi_safi_afi_safi_name": "AFI/SAFI",
+                "neighbor_neighbor_address 1": "Neighbor IP",
                 "network_instance_name 1": "VRF",
                 "session_state": "Session State",
-                "source": "Hostname",
                 "source 1": "Hostname"
               }
             }


### PR DESCRIPTION
## Change Summary

Add EVPN telemetry dashboard and enhance L3 telemetry dashboard for the gNMIc-Prometheus-Grafana lab.

- **New**: `evpn-telemetry.json` — 11-panel dashboard covering EVPN BGP summary, session states, peer counts, route counts, prefix tracking, and overlay stability monitoring
- **Enhanced**: `l3-telemetry.json` — expanded from 1 panel (BGP summary table) to 7 panels including BGP session states pie chart, established/total peer stats, flap counts, neighbor detail table, and prefix tracking over time

## Related Issue(s)

N/A

### Repository Checklist

- [x] My code has been rebased from the upstream `main` branch

