### PR TITLE
update sandbox container rev to 1.0.1

### DIFF
--- a/.devcontainer/sandbox/devcontainer.json
+++ b/.devcontainer/sandbox/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "ghcr.io/${localEnv:GITHUB_REPOSITORY}/sandbox:latest-clab-rev1.0.0",
+    "image": "ghcr.io/${localEnv:GITHUB_REPOSITORY}/sandbox:latest-clab-rev1.0.1",
     // containerEnv set the variables applied to entire container
     "containerEnv": {
         "ARISTA_TOKEN": "${localEnv:ARTOKEN}",

--- a/.github/workflows/container_build_parent_matrix_sandbox.yml
+++ b/.github/workflows/container_build_parent_matrix_sandbox.yml
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/container_build_child.yml
     strategy:
       matrix:
-        from_image: ["ghcr.io/aristanetworks/aclabs/lab-base:python3.12-avd-v6.1.0-clab0.74.3-rev2.6.6-uid1009"]
+        from_image: ["ghcr.io/aristanetworks/aclabs/lab-base:python3.12-avd-v6.1.0-clab0.75.0-rev2.6.7-uid1009"]
         user_id: ["1009"]
 
     with:
@@ -31,4 +31,6 @@ jobs:
       user_id: ${{ matrix.user_id }}
       # 1.0.0:
       # - Initial release of sandbox container
-      container_revision: "1.0.0"
+      # 1.0.1:
+      # - Set base from_image to lab-base:python3.12-avd-v6.1.0-clab0.75.0-rev2.6.7-uid1009
+      container_revision: "1.0.1"


### PR DESCRIPTION
## Change Summary

- Update sandbox container to use from_image of `lab-base:python3.12-avd-v6.1.0-clab0.75.0-rev2.6.7-uid1009`

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from the upstream `main` branch
