### PR TITLE
minor update to avd data models for techlib labs

### DIFF
--- a/labs/techlib-mlag-fabric/avd/global_vars/all.yml
+++ b/labs/techlib-mlag-fabric/avd/global_vars/all.yml
@@ -20,9 +20,6 @@ custom_structured_configuration_arp:
   aging:
     timeout_default: 1500
 
-# Stop build if validation error is encountered
-avd_data_validation_mode: error
-
 # DNS Settings
 dns_settings:
   domain: aclabs.lab

--- a/labs/techlib-vxlan-domain-a/avd/group_vars/all.yml
+++ b/labs/techlib-vxlan-domain-a/avd/group_vars/all.yml
@@ -20,9 +20,6 @@ custom_structured_configuration_arp:
   aging:
     timeout_default: 1500
 
-# Stop build if validation error is encountered
-avd_data_validation_mode: error
-
 # DNS Settings
 dns_settings:
   domain: aclabs.lab

--- a/labs/techlib-vxlan-domain-b/avd/group_vars/all.yml
+++ b/labs/techlib-vxlan-domain-b/avd/group_vars/all.yml
@@ -20,9 +20,6 @@ custom_structured_configuration_arp:
   aging:
     timeout_default: 1500
 
-# Stop build if validation error is encountered
-avd_data_validation_mode: error
-
 # DNS Settings
 dns_settings:
   domain: aclabs.lab


### PR DESCRIPTION
## Change Summary

- Remove `avd_data_validation_mode: error` global variable from all techlib labs (no longer supported as of AVD `6.1.0`

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from the upstream `main` branch
