### PR TITLE
update sandbox default topo to use ubuntu rev1.4

### DIFF
--- a/labs/sandbox/topology.clab.yml
+++ b/labs/sandbox/topology.clab.yml
@@ -18,6 +18,6 @@ topology:
         CLAB_MGMT_VRF: MGMT
         INTFTYPE: et
     linux:
-      image: ghcr.io/aristanetworks/aclabs/host-ubuntu:rev1.2
+      image: ghcr.io/aristanetworks/aclabs/host-ubuntu:rev1.4
   nodes: {}
   links: []


### PR DESCRIPTION
## Change Summary

- Update sandbox default topology file to use Ubuntu Host `rev1.4`

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from the upstream `main` branch
