### PR TITLE
update sandbox lab dashboard to rev 0.17.44

### DIFF
--- a/containers/sandbox/.devcontainer/Dockerfile
+++ b/containers/sandbox/.devcontainer/Dockerfile
@@ -22,4 +22,4 @@ RUN chown ${USERNAME} /home/${USERNAME}/.local/share/code-server/User/settings.j
 
 USER ${USERNAME}
 
-RUN code-server --install-extension PacketAnglers.sandbox-dashboard@0.17.43 --force
+RUN code-server --install-extension PacketAnglers.sandbox-dashboard@0.17.44 --force


### PR DESCRIPTION
## Change Summary

- Update sandbox dashboard to rev 0.17.44 (Enable users to more easily clear a current CVaaS token)

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from the upstream `main` branch
