### PR TITLE
Deployment guide for gNMI

### DIFF
--- a/docs/assets/img/gnmic-pg-dial-in.svg
+++ b/docs/assets/img/gnmic-pg-dial-in.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 380" font-family="Roboto, Arial, sans-serif" font-size="12">
+  <defs>
+    <marker id="arr-solid" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#5a6b7d"/>
+    </marker>
+    <marker id="arr-dashed" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#a23b72"/>
+    </marker>
+    <marker id="arr-return" viewBox="0 0 10 10" refX="1" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M 10 0 L 0 5 L 10 10 z" fill="#6f9654"/>
+    </marker>
+    <style>
+      .title    { font-weight: 700; font-size: 15px; fill: #1a2733; }
+      .box-cli  { fill: #a23b72; stroke: #6e2751; stroke-width: 1.5; }
+      .box-srv  { fill: #2e86ab; stroke: #1f5a75; stroke-width: 1.5; }
+      .box-lbl  { fill: #fff; font-weight: 600; text-anchor: middle; }
+      .box-lbl2 { fill: #fff; font-size: 10px; font-weight: 400; text-anchor: middle; }
+      .arrow-solid  { stroke: #5a6b7d; stroke-width: 2; fill: none; marker-end: url(#arr-solid); }
+      .arrow-dashed { stroke: #a23b72; stroke-width: 1.8; fill: none; stroke-dasharray: 5 3; marker-end: url(#arr-dashed); }
+      .arrow-stream { stroke: #6f9654; stroke-width: 1.8; fill: none; stroke-dasharray: 2 3; marker-start: url(#arr-return); }
+      .step-num { fill: #fff; font-weight: 700; font-size: 11px; text-anchor: middle; }
+      .step-cir { fill: #f18f01; stroke: #b96e00; }
+      .label    { fill: #333; font-size: 12px; }
+      .caption  { fill: #666; font-size: 11px; text-anchor: middle; font-style: italic; }
+    </style>
+  </defs>
+  <text x="450" y="24" text-anchor="middle" class="title">gNMI Dial-In — how the collector reaches the switch</text>
+
+  <!-- Client / collector -->
+  <rect x="60" y="130" width="160" height="70" rx="8" class="box-cli"/>
+  <text x="140" y="155" class="box-lbl">gNMIc collector</text>
+  <text x="140" y="172" class="box-lbl2">container: gnmic</text>
+  <text x="140" y="188" class="box-lbl2">172.144.100.200</text>
+
+  <!-- Server -->
+  <rect x="680" y="130" width="160" height="70" rx="8" class="box-srv"/>
+  <text x="760" y="155" class="box-lbl">cEOS switch</text>
+  <text x="760" y="172" class="box-lbl2">management api gnmi</text>
+  <text x="760" y="188" class="box-lbl2">transport grpc MGMT :6030</text>
+
+  <!-- Step 1: TCP + TLS + gRPC connect -->
+  <line x1="220" y1="150" x2="680" y2="150" class="arrow-solid"/>
+  <circle cx="240" cy="140" r="11" class="step-cir"/>
+  <text x="240" y="144" class="step-num">1</text>
+  <text x="450" y="140" text-anchor="middle" class="label">TCP :6030 → TLS handshake → gRPC connect</text>
+
+  <!-- Step 2: Subscribe RPC request -->
+  <line x1="220" y1="175" x2="680" y2="175" class="arrow-dashed"/>
+  <circle cx="240" cy="185" r="11" class="step-cir"/>
+  <text x="240" y="189" class="step-num">2</text>
+  <text x="450" y="200" text-anchor="middle" class="label">SubscribeRequest (paths, mode, stream-mode, interval)</text>
+
+  <!-- Step 3: server pushes updates -->
+  <line x1="220" y1="220" x2="680" y2="220" class="arrow-stream"/>
+  <circle cx="680" cy="230" r="11" class="step-cir"/>
+  <text x="680" y="234" class="step-num">3</text>
+  <text x="450" y="240" text-anchor="middle" class="label">server pushes SubscribeResponse updates on the long-lived stream</text>
+
+  <!-- Legend -->
+  <g transform="translate(60,280)">
+    <line x1="0" y1="0" x2="30" y2="0" class="arrow-solid"/>
+    <text x="40" y="4" class="label">Connection initiated by collector (dial-in)</text>
+    <line x1="0" y1="18" x2="30" y2="18" class="arrow-dashed"/>
+    <text x="40" y="22" class="label">RPC request over the gRPC channel</text>
+    <line x1="0" y1="36" x2="30" y2="36" class="arrow-stream"/>
+    <text x="40" y="40" class="label">Server streams updates back</text>
+  </g>
+
+  <text x="450" y="355" class="caption">Dial-in is the model the lab uses. Dial-out (switch initiates via a gRPC tunnel to the collector) is a valid alternative when firewalls or NAT block the reverse direction.</text>
+</svg>

--- a/docs/assets/img/gnmic-pg-overlay.svg
+++ b/docs/assets/img/gnmic-pg-overlay.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 500" font-family="Roboto, Arial, sans-serif" font-size="12">
+  <defs>
+    <style>
+      .role-spine { fill: #f18f01; stroke: #b96e00; stroke-width: 1.5; }
+      .role-leaf  { fill: #2e86ab; stroke: #1f5a75; stroke-width: 1.5; }
+      .evpn       { stroke: #a23b72; stroke-width: 2; fill: none; stroke-dasharray: 6 3; }
+      .vxlan      { stroke: #6f9654; stroke-width: 2.5; fill: none; }
+      .nodelbl    { fill: #fff; font-weight: 600; text-anchor: middle; }
+      .vtep-lbl   { fill: #333; text-anchor: middle; font-size: 10px; }
+      .title      { font-weight: 700; font-size: 15px; fill: #1a2733; }
+      .caption    { fill: #555; font-size: 12px; text-anchor: middle; }
+      .badge      { fill: #6f9654; stroke: #4a6738; }
+    </style>
+  </defs>
+  <text x="450" y="24" text-anchor="middle" class="title">EVPN Overlay — eBGP L2VPN-EVPN peerings, VXLAN data plane</text>
+
+  <!-- Spines: RR-like role (transit for EVPN) -->
+  <rect x="230" y="70" width="140" height="55" rx="6" class="role-spine"/>
+  <text x="300" y="90" class="nodelbl">spine1</text>
+  <text x="300" y="108" class="nodelbl" font-size="10" font-weight="400">EVPN transit • next-hop-unchanged</text>
+
+  <rect x="530" y="70" width="140" height="55" rx="6" class="role-spine"/>
+  <text x="600" y="90" class="nodelbl">spine2</text>
+  <text x="600" y="108" class="nodelbl" font-size="10" font-weight="400">EVPN transit • next-hop-unchanged</text>
+
+  <!-- Leaves as VTEPs -->
+  <g>
+    <rect x="40"  y="290" width="180" height="65" rx="6" class="role-leaf"/>
+    <text x="130" y="310" class="nodelbl">pe11 (VTEP)</text>
+    <text x="130" y="328" class="nodelbl" font-size="10" font-weight="400">Lo1 192.168.254.3</text>
+    <text x="130" y="343" class="nodelbl" font-size="10" font-weight="400">VNI 10110, 10111</text>
+
+    <rect x="240" y="290" width="180" height="65" rx="6" class="role-leaf"/>
+    <text x="330" y="310" class="nodelbl">pe12 (VTEP)</text>
+    <text x="330" y="328" class="nodelbl" font-size="10" font-weight="400">Lo1 192.168.254.4</text>
+    <text x="330" y="343" class="nodelbl" font-size="10" font-weight="400">VNI 10110, 10111</text>
+
+    <rect x="480" y="290" width="180" height="65" rx="6" class="role-leaf"/>
+    <text x="570" y="310" class="nodelbl">pe21 (VTEP)</text>
+    <text x="570" y="328" class="nodelbl" font-size="10" font-weight="400">Lo1 192.168.254.5</text>
+    <text x="570" y="343" class="nodelbl" font-size="10" font-weight="400">VNI 10110, 10111</text>
+
+    <rect x="680" y="290" width="180" height="65" rx="6" class="role-leaf"/>
+    <text x="770" y="310" class="nodelbl">pe22 (VTEP)</text>
+    <text x="770" y="328" class="nodelbl" font-size="10" font-weight="400">Lo1 192.168.254.6</text>
+    <text x="770" y="343" class="nodelbl" font-size="10" font-weight="400">VNI 10110, 10111</text>
+  </g>
+
+  <!-- EVPN peerings (leaf<->spine, dashed) -->
+  <g>
+    <line x1="290" y1="125" x2="130" y2="290" class="evpn"/>
+    <line x1="300" y1="125" x2="330" y2="290" class="evpn"/>
+    <line x1="315" y1="125" x2="570" y2="290" class="evpn"/>
+    <line x1="330" y1="125" x2="770" y2="290" class="evpn"/>
+
+    <line x1="570" y1="125" x2="130" y2="290" class="evpn"/>
+    <line x1="585" y1="125" x2="330" y2="290" class="evpn"/>
+    <line x1="600" y1="125" x2="570" y2="290" class="evpn"/>
+    <line x1="615" y1="125" x2="770" y2="290" class="evpn"/>
+  </g>
+
+  <!-- VXLAN tunnels (leaf<->leaf, solid) -->
+  <g>
+    <path d="M 130 355 Q 200 420, 330 355" class="vxlan"/>
+    <path d="M 330 355 Q 450 440, 570 355" class="vxlan"/>
+    <path d="M 570 355 Q 640 420, 770 355" class="vxlan"/>
+    <path d="M 130 355 Q 450 460, 770 355" class="vxlan"/>
+  </g>
+
+  <!-- Caption / legend -->
+  <text x="450" y="420" class="caption">Dashed magenta: L2VPN-EVPN AFI/SAFI peerings sourced from Loopback0, `ebgp-multihop 3`.</text>
+  <text x="450" y="438" class="caption">Green: VXLAN data plane between VTEPs (Loopback1), UDP/4789, one VNI per tenant VLAN.</text>
+  <text x="450" y="470" class="caption" font-style="italic">Multi-homed clients advertise MAC/IP via Type-2 routes tagged with the pair's ESI (Type-1 A-D routes for split-horizon).</text>
+</svg>

--- a/docs/assets/img/gnmic-pg-pipeline.svg
+++ b/docs/assets/img/gnmic-pg-pipeline.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 460" font-family="Roboto, Arial, sans-serif" font-size="12">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#5a6b7d"/>
+    </marker>
+    <style>
+      .box-switch { fill: #2e86ab; stroke: #1f5a75; stroke-width: 1.5; }
+      .box-gnmic  { fill: #a23b72; stroke: #6e2751; stroke-width: 1.5; }
+      .box-prom   { fill: #f5c518; stroke: #b08d10; stroke-width: 1.5; }
+      .box-graf   { fill: #6f9654; stroke: #4a6738; stroke-width: 1.5; }
+      .arrow      { stroke: #5a6b7d; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+      .title      { font-weight: 700; font-size: 15px; fill: #1a2733; }
+      .box-lbl    { fill: #fff; font-weight: 600; text-anchor: middle; }
+      .box-lbl2   { fill: #fff; font-size: 10px; font-weight: 400; text-anchor: middle; }
+      .box-lbl3   { fill: #333; font-size: 10px; font-weight: 400; text-anchor: middle; }
+      .hop-lbl    { fill: #444; font-size: 11px; text-anchor: middle; font-weight: 600; }
+      .detail     { fill: #666; font-size: 10px; text-anchor: middle; }
+    </style>
+  </defs>
+  <text x="480" y="24" text-anchor="middle" class="title">Telemetry Pipeline — YANG on the switch, PromQL on the dashboard</text>
+
+  <!-- Hop 1: switches -->
+  <rect x="40" y="150" width="150" height="80" rx="8" class="box-switch"/>
+  <text x="115" y="175" class="box-lbl">cEOS switches (×6)</text>
+  <text x="115" y="193" class="box-lbl2">management api gnmi</text>
+  <text x="115" y="207" class="box-lbl2">transport grpc MGMT</text>
+  <text x="115" y="221" class="box-lbl2">provider eos-native</text>
+
+  <!-- Hop 2: gnmic -->
+  <rect x="290" y="150" width="180" height="80" rx="8" class="box-gnmic"/>
+  <text x="380" y="175" class="box-lbl">gNMIc collector</text>
+  <text x="380" y="193" class="box-lbl2">17 subscriptions (stream)</text>
+  <text x="380" y="207" class="box-lbl2">5 event processors</text>
+  <text x="380" y="221" class="box-lbl2">exposes /metrics :9273</text>
+
+  <!-- Hop 3: prometheus -->
+  <rect x="570" y="150" width="170" height="80" rx="8" class="box-prom"/>
+  <text x="655" y="175" class="box-lbl" fill="#333">Prometheus TSDB</text>
+  <text x="655" y="193" class="box-lbl3">scrape_interval: 5s</text>
+  <text x="655" y="207" class="box-lbl3">gnmic:9273/metrics</text>
+  <text x="655" y="221" class="box-lbl3">time-series store</text>
+
+  <!-- Hop 4: grafana -->
+  <rect x="820" y="150" width="120" height="80" rx="8" class="box-graf"/>
+  <text x="880" y="175" class="box-lbl">Grafana</text>
+  <text x="880" y="193" class="box-lbl2">5 dashboards</text>
+  <text x="880" y="207" class="box-lbl2">PromQL queries</text>
+  <text x="880" y="221" class="box-lbl2">alerts / panels</text>
+
+  <!-- Arrows -->
+  <line x1="190" y1="190" x2="285" y2="190" class="arrow"/>
+  <line x1="470" y1="190" x2="565" y2="190" class="arrow"/>
+  <line x1="740" y1="190" x2="815" y2="190" class="arrow"/>
+
+  <!-- Hop labels -->
+  <text x="238" y="145" class="hop-lbl">gNMI :6030</text>
+  <text x="238" y="245" class="detail">subscribe, stream</text>
+  <text x="238" y="258" class="detail">JSON_IETF</text>
+
+  <text x="518" y="145" class="hop-lbl">HTTP scrape</text>
+  <text x="518" y="245" class="detail">every 5s</text>
+  <text x="518" y="258" class="detail">/metrics</text>
+
+  <text x="778" y="145" class="hop-lbl">PromQL</text>
+  <text x="778" y="245" class="detail">datasource</text>
+
+  <!-- Below: sample data flow -->
+  <g transform="translate(40,300)">
+    <text x="0" y="0" font-weight="600" fill="#1a2733">Example: interface oper-status from cEOS to Grafana</text>
+    <text x="0" y="20" fill="#333">1. Switch:  <tspan font-family="Roboto Mono, monospace">/interfaces/interface[name=Ethernet1]/state/oper-status</tspan>  →  <tspan font-family="Roboto Mono, monospace">"UP"</tspan></text>
+    <text x="0" y="40" fill="#333">2. gNMIc:   trim-prefixes strips path,  bounce-map converts UP→1,  DOWN→0</text>
+    <text x="0" y="60" fill="#333">3. Prom:    <tspan font-family="Roboto Mono, monospace">gnmic_intf_oper_state_oper_status{source="spine1",interface_name="Ethernet1"} 1</tspan></text>
+    <text x="0" y="80" fill="#333">4. Grafana: <tspan font-family="Roboto Mono, monospace">sum by (source)(gnmic_intf_oper_state_oper_status == 1)</tspan>  →  fabric-health tile</text>
+  </g>
+
+  <text x="480" y="435" class="detail" font-style="italic">Each hop is a single config file. When a Grafana panel looks wrong, the bug is on one of these four hops.</text>
+</svg>

--- a/docs/assets/img/gnmic-pg-stream-modes.svg
+++ b/docs/assets/img/gnmic-pg-stream-modes.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 460" font-family="Roboto, Arial, sans-serif" font-size="12">
+  <defs>
+    <style>
+      .title      { font-weight: 700; font-size: 15px; fill: #1a2733; }
+      .row-lbl    { fill: #1a2733; font-weight: 600; font-size: 12px; }
+      .axis       { stroke: #999; stroke-width: 1; fill: none; }
+      .axis-tick  { stroke: #999; stroke-width: 1; }
+      .tick-lbl   { fill: #666; font-size: 10px; text-anchor: middle; }
+      .event      { fill: #d64545; }
+      .event-lbl  { fill: #d64545; font-size: 11px; font-weight: 600; text-anchor: middle; }
+      .push       { fill: #2e86ab; }
+      .push-hb    { fill: #6f9654; }
+      .push-sample{ fill: #f18f01; }
+      .push-tgt   { fill: #a23b72; }
+      .row-bg     { fill: #f4f6f8; }
+      .row-note   { fill: #666; font-size: 10px; font-style: italic; }
+      .caption    { fill: #666; font-size: 11px; text-anchor: middle; font-style: italic; }
+    </style>
+  </defs>
+  <text x="480" y="24" text-anchor="middle" class="title">Stream Modes — same path, four subscription shapes, one link flap</text>
+
+  <!-- Event markers (link goes DOWN at t=10s, UP at t=25s) -->
+  <line x1="240" y1="60" x2="240" y2="410" stroke="#d64545" stroke-width="1" stroke-dasharray="3 3"/>
+  <line x1="480" y1="60" x2="480" y2="410" stroke="#d64545" stroke-width="1" stroke-dasharray="3 3"/>
+  <text x="240" y="55" class="event-lbl">link DOWN @ t=10s</text>
+  <text x="480" y="55" class="event-lbl">link UP @ t=25s</text>
+
+  <!-- Time axis at bottom -->
+  <line x1="120" y1="405" x2="920" y2="405" class="axis"/>
+  <g>
+    <line x1="120" y1="405" x2="120" y2="410" class="axis-tick"/><text x="120" y="425" class="tick-lbl">0s</text>
+    <line x1="200" y1="405" x2="200" y2="410" class="axis-tick"/><text x="200" y="425" class="tick-lbl">5</text>
+    <line x1="280" y1="405" x2="280" y2="410" class="axis-tick"/><text x="280" y="425" class="tick-lbl">10</text>
+    <line x1="360" y1="405" x2="360" y2="410" class="axis-tick"/><text x="360" y="425" class="tick-lbl">15</text>
+    <line x1="440" y1="405" x2="440" y2="410" class="axis-tick"/><text x="440" y="425" class="tick-lbl">20</text>
+    <line x1="520" y1="405" x2="520" y2="410" class="axis-tick"/><text x="520" y="425" class="tick-lbl">25</text>
+    <line x1="600" y1="405" x2="600" y2="410" class="axis-tick"/><text x="600" y="425" class="tick-lbl">30</text>
+    <line x1="680" y1="405" x2="680" y2="410" class="axis-tick"/><text x="680" y="425" class="tick-lbl">35</text>
+    <line x1="760" y1="405" x2="760" y2="410" class="axis-tick"/><text x="760" y="425" class="tick-lbl">40</text>
+    <line x1="840" y1="405" x2="840" y2="410" class="axis-tick"/><text x="840" y="425" class="tick-lbl">45s</text>
+  </g>
+
+  <!-- Row: SAMPLE (every 5s) -->
+  <rect x="115" y="75" width="810" height="60" rx="4" class="row-bg"/>
+  <text x="10" y="95" class="row-lbl">SAMPLE</text>
+  <text x="10" y="112" class="row-note">every 5s</text>
+  <text x="10" y="127" class="row-note">regardless of change</text>
+  <g class="push-sample">
+    <circle cx="120" cy="105" r="6"/>
+    <circle cx="200" cy="105" r="6"/>
+    <circle cx="280" cy="105" r="6"/>
+    <circle cx="360" cy="105" r="6"/>
+    <circle cx="440" cy="105" r="6"/>
+    <circle cx="520" cy="105" r="6"/>
+    <circle cx="600" cy="105" r="6"/>
+    <circle cx="680" cy="105" r="6"/>
+    <circle cx="760" cy="105" r="6"/>
+    <circle cx="840" cy="105" r="6"/>
+  </g>
+  <text x="920" y="110" class="row-note">10 pushes</text>
+
+  <!-- Row: ON_CHANGE -->
+  <rect x="115" y="145" width="810" height="60" rx="4" class="row-bg"/>
+  <text x="10" y="170" class="row-lbl">ON_CHANGE</text>
+  <text x="10" y="185" class="row-note">only when value</text>
+  <text x="10" y="198" class="row-note">actually changes</text>
+  <g class="push">
+    <circle cx="120" cy="175" r="6"/>
+    <circle cx="240" cy="175" r="6"/>
+    <circle cx="480" cy="175" r="6"/>
+  </g>
+  <text x="920" y="180" class="row-note">3 pushes</text>
+  <text x="120" y="145" class="tick-lbl">sync</text>
+
+  <!-- Row: ON_CHANGE + heartbeat 20s -->
+  <rect x="115" y="215" width="810" height="60" rx="4" class="row-bg"/>
+  <text x="10" y="238" class="row-lbl">ON_CHANGE</text>
+  <text x="10" y="252" class="row-lbl">+ heartbeat 20s</text>
+  <text x="10" y="268" class="row-note">change + keepalive</text>
+  <g class="push">
+    <circle cx="120" cy="245" r="6"/>
+    <circle cx="240" cy="245" r="6"/>
+    <circle cx="480" cy="245" r="6"/>
+  </g>
+  <g class="push-hb">
+    <circle cx="440" cy="245" r="5"/>
+    <circle cx="680" cy="245" r="5"/>
+    <circle cx="880" cy="245" r="5"/>
+  </g>
+  <text x="920" y="250" class="row-note">3 + 3 pushes</text>
+
+  <!-- Row: TARGET_DEFINED -->
+  <rect x="115" y="285" width="810" height="90" rx="4" class="row-bg"/>
+  <text x="10" y="308" class="row-lbl">TARGET_</text>
+  <text x="10" y="323" class="row-lbl">DEFINED</text>
+  <text x="10" y="340" class="row-note">EOS auto-splits:</text>
+  <text x="10" y="353" class="row-note">state → on_change,</text>
+  <text x="10" y="366" class="row-note">counters → sample</text>
+  <!-- oper-status on_change events -->
+  <g class="push">
+    <circle cx="120" cy="308" r="6"/>
+    <circle cx="240" cy="308" r="6"/>
+    <circle cx="480" cy="308" r="6"/>
+  </g>
+  <text x="480" y="298" class="tick-lbl">/state/oper-status → on_change</text>
+  <!-- counters sample events -->
+  <g class="push-sample">
+    <circle cx="120" cy="350" r="6"/>
+    <circle cx="200" cy="350" r="6"/>
+    <circle cx="280" cy="350" r="6"/>
+    <circle cx="360" cy="350" r="6"/>
+    <circle cx="440" cy="350" r="6"/>
+    <circle cx="520" cy="350" r="6"/>
+    <circle cx="600" cy="350" r="6"/>
+    <circle cx="680" cy="350" r="6"/>
+    <circle cx="760" cy="350" r="6"/>
+    <circle cx="840" cy="350" r="6"/>
+  </g>
+  <text x="480" y="378" class="tick-lbl">/state/counters/* → sample @ 5s</text>
+
+  <!-- Legend -->
+  <g transform="translate(120,438)" font-size="10" fill="#666">
+    <circle cx="0" cy="0" r="5" class="push-sample"/><text x="10" y="4">SAMPLE push</text>
+    <circle cx="130" cy="0" r="5" class="push"/><text x="140" y="4">ON_CHANGE push</text>
+    <circle cx="270" cy="0" r="5" class="push-hb"/><text x="280" y="4">heartbeat</text>
+    <line x1="360" y1="-4" x2="360" y2="4" stroke="#d64545"/><text x="368" y="4">link transition</text>
+  </g>
+</svg>

--- a/docs/assets/img/gnmic-pg-topo-physical.svg
+++ b/docs/assets/img/gnmic-pg-topo-physical.svg
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 620" font-family="Roboto, Arial, sans-serif" font-size="12">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#5a6b7d"/>
+    </marker>
+    <style>
+      .role-spine { fill: #f18f01; stroke: #b96e00; stroke-width: 1.5; }
+      .role-leaf  { fill: #2e86ab; stroke: #1f5a75; stroke-width: 1.5; }
+      .role-host  { fill: #c9d6df; stroke: #7a8a95; stroke-width: 1.5; }
+      .role-svc   { fill: #a23b72; stroke: #6e2751; stroke-width: 1.5; }
+      .role-tsdb  { fill: #f5c518; stroke: #b08d10; stroke-width: 1.5; }
+      .role-viz   { fill: #6f9654; stroke: #4a6738; stroke-width: 1.5; }
+      .p2p        { stroke: #5a6b7d; stroke-width: 1.5; fill: none; }
+      .host-link  { stroke: #7a8a95; stroke-width: 1; fill: none; stroke-dasharray: 3 2; }
+      .mgmt       { stroke: #999; stroke-width: 1; fill: none; stroke-dasharray: 2 3; }
+      .nodelbl    { fill: #fff; font-weight: 600; text-anchor: middle; }
+      .iplbl      { fill: #333; text-anchor: middle; font-size: 10px; }
+      .tag        { fill: #444; font-size: 11px; text-anchor: middle; }
+      .title      { font-weight: 700; font-size: 15px; fill: #1a2733; }
+    </style>
+  </defs>
+  <text x="450" y="24" text-anchor="middle" class="title">gNMIc Prometheus Grafana Telemetry Lab — Physical Topology</text>
+
+  <!-- Spines -->
+  <g>
+    <rect x="230" y="70" width="140" height="50" rx="6" class="role-spine"/>
+    <text x="300" y="90" class="nodelbl">spine1</text>
+    <text x="300" y="107" class="nodelbl" font-size="11" font-weight="400">172.144.100.2</text>
+    <rect x="530" y="70" width="140" height="50" rx="6" class="role-spine"/>
+    <text x="600" y="90" class="nodelbl">spine2</text>
+    <text x="600" y="107" class="nodelbl" font-size="11" font-weight="400">172.144.100.3</text>
+  </g>
+
+  <!-- Leaves -->
+  <g>
+    <rect x="60"  y="210" width="130" height="48" rx="6" class="role-leaf"/>
+    <text x="125" y="230" class="nodelbl">pe11</text>
+    <text x="125" y="246" class="nodelbl" font-size="10" font-weight="400">.4  •  AS 65101</text>
+
+    <rect x="220" y="210" width="130" height="48" rx="6" class="role-leaf"/>
+    <text x="285" y="230" class="nodelbl">pe12</text>
+    <text x="285" y="246" class="nodelbl" font-size="10" font-weight="400">.5  •  AS 65102</text>
+
+    <rect x="550" y="210" width="130" height="48" rx="6" class="role-leaf"/>
+    <text x="615" y="230" class="nodelbl">pe21</text>
+    <text x="615" y="246" class="nodelbl" font-size="10" font-weight="400">.6  •  AS 65103</text>
+
+    <rect x="710" y="210" width="130" height="48" rx="6" class="role-leaf"/>
+    <text x="775" y="230" class="nodelbl">pe22</text>
+    <text x="775" y="246" class="nodelbl" font-size="10" font-weight="400">.7  •  AS 65104</text>
+  </g>
+
+  <!-- POD labels -->
+  <text x="205" y="200" class="tag" font-weight="600">POD_1</text>
+  <text x="695" y="200" class="tag" font-weight="600">POD_2</text>
+
+  <!-- Spine <-> Leaf underlay links (P2P /31) -->
+  <g>
+    <line x1="270" y1="120" x2="125" y2="210" class="p2p"/>
+    <line x1="290" y1="120" x2="285" y2="210" class="p2p"/>
+    <line x1="310" y1="120" x2="615" y2="210" class="p2p"/>
+    <line x1="330" y1="120" x2="775" y2="210" class="p2p"/>
+
+    <line x1="570" y1="120" x2="125" y2="210" class="p2p"/>
+    <line x1="590" y1="120" x2="285" y2="210" class="p2p"/>
+    <line x1="610" y1="120" x2="615" y2="210" class="p2p"/>
+    <line x1="630" y1="120" x2="775" y2="210" class="p2p"/>
+  </g>
+  <text x="450" y="170" class="tag">P2P /31 links from 172.31.255.0/24 pool</text>
+
+  <!-- Clients -->
+  <g>
+    <rect x="40"  y="360" width="100" height="42" rx="6" class="role-host"/>
+    <text x="90" y="378" class="nodelbl" fill="#1a2733">client1</text>
+    <text x="90" y="393" class="nodelbl" fill="#1a2733" font-size="10" font-weight="400">.8 (LACP)</text>
+
+    <rect x="160" y="360" width="100" height="42" rx="6" class="role-host"/>
+    <text x="210" y="378" class="nodelbl" fill="#1a2733">client2</text>
+    <text x="210" y="393" class="nodelbl" fill="#1a2733" font-size="10" font-weight="400">.9 (LACP)</text>
+
+    <rect x="540" y="360" width="100" height="42" rx="6" class="role-host"/>
+    <text x="590" y="378" class="nodelbl" fill="#1a2733">client3</text>
+    <text x="590" y="393" class="nodelbl" fill="#1a2733" font-size="10" font-weight="400">.10 (LACP)</text>
+
+    <rect x="660" y="360" width="100" height="42" rx="6" class="role-host"/>
+    <text x="710" y="378" class="nodelbl" fill="#1a2733">client4</text>
+    <text x="710" y="393" class="nodelbl" fill="#1a2733" font-size="10" font-weight="400">.11 (LACP)</text>
+  </g>
+
+  <!-- Client <-> Leaf dual-attach (ESI/LACP) -->
+  <g>
+    <line x1="90"  y1="360" x2="125" y2="258" class="host-link"/>
+    <line x1="90"  y1="360" x2="285" y2="258" class="host-link"/>
+    <line x1="210" y1="360" x2="125" y2="258" class="host-link"/>
+    <line x1="210" y1="360" x2="285" y2="258" class="host-link"/>
+
+    <line x1="590" y1="360" x2="615" y2="258" class="host-link"/>
+    <line x1="590" y1="360" x2="775" y2="258" class="host-link"/>
+    <line x1="710" y1="360" x2="615" y2="258" class="host-link"/>
+    <line x1="710" y1="360" x2="775" y2="258" class="host-link"/>
+  </g>
+  <text x="150" y="340" class="tag">EVPN ESI + LACP</text>
+  <text x="650" y="340" class="tag">EVPN ESI + LACP</text>
+
+  <!-- Telemetry stack (mgmt network sidebar) -->
+  <g>
+    <rect x="330" y="470" width="240" height="120" rx="8" fill="#eef3f6" stroke="#7a8a95" stroke-dasharray="3 3"/>
+    <text x="450" y="490" text-anchor="middle" font-weight="600" fill="#1a2733">Telemetry stack (mgmt network)</text>
+
+    <rect x="345" y="500" width="70" height="35" rx="4" class="role-svc"/>
+    <text x="380" y="515" class="nodelbl">gnmic</text>
+    <text x="380" y="528" class="nodelbl" font-size="9" font-weight="400">.200</text>
+
+    <rect x="425" y="500" width="70" height="35" rx="4" class="role-tsdb"/>
+    <text x="460" y="515" class="nodelbl" fill="#333">prom</text>
+    <text x="460" y="528" class="nodelbl" fill="#333" font-size="9" font-weight="400">.210 :9090</text>
+
+    <rect x="505" y="500" width="65" height="35" rx="4" class="role-viz"/>
+    <text x="537" y="515" class="nodelbl">grafana</text>
+    <text x="537" y="528" class="nodelbl" font-size="9" font-weight="400">.220 :3001</text>
+
+    <text x="450" y="560" class="tag">gnmic :6030 gRPC ← all switches</text>
+    <text x="450" y="575" class="tag">prom scrape gnmic:9273/metrics every 5s</text>
+  </g>
+
+  <!-- mgmt dotted links from switches to gnmic -->
+  <g>
+    <line x1="300" y1="120" x2="380" y2="500" class="mgmt"/>
+    <line x1="600" y1="120" x2="380" y2="500" class="mgmt"/>
+    <line x1="125" y1="258" x2="380" y2="500" class="mgmt"/>
+    <line x1="285" y1="258" x2="380" y2="500" class="mgmt"/>
+    <line x1="615" y1="258" x2="380" y2="500" class="mgmt"/>
+    <line x1="775" y1="258" x2="380" y2="500" class="mgmt"/>
+  </g>
+
+  <!-- Legend -->
+  <g transform="translate(680,470)">
+    <rect x="0" y="0" width="200" height="120" rx="6" fill="#fafbfc" stroke="#c8d1d9"/>
+    <text x="12" y="18" font-weight="600" fill="#1a2733">Legend</text>
+    <rect x="12" y="28" width="16" height="10" class="role-spine"/><text x="36" y="37">Spine (AS 65001)</text>
+    <rect x="12" y="44" width="16" height="10" class="role-leaf"/><text x="36" y="53">Leaf / VTEP (65101–65104)</text>
+    <rect x="12" y="60" width="16" height="10" class="role-host"/><text x="36" y="69">Client (LACP bond)</text>
+    <line x1="12" y1="82" x2="30" y2="82" class="p2p"/><text x="36" y="86">Underlay P2P /31</text>
+    <line x1="12" y1="97" x2="30" y2="97" class="host-link"/><text x="36" y="101">EVPN multi-homed</text>
+    <line x1="12" y1="112" x2="30" y2="112" class="mgmt"/><text x="36" y="115">Mgmt (gNMI)</text>
+  </g>
+</svg>

--- a/docs/assets/img/gnmic-pg-underlay.svg
+++ b/docs/assets/img/gnmic-pg-underlay.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 500" font-family="Roboto, Arial, sans-serif" font-size="12">
+  <defs>
+    <style>
+      .role-spine { fill: #f18f01; stroke: #b96e00; stroke-width: 1.5; }
+      .role-leaf  { fill: #2e86ab; stroke: #1f5a75; stroke-width: 1.5; }
+      .underlay   { stroke: #5a6b7d; stroke-width: 2; fill: none; }
+      .nodelbl    { fill: #fff; font-weight: 600; text-anchor: middle; }
+      .as         { fill: #333; text-anchor: middle; font-size: 11px; font-weight: 600; }
+      .link-lbl   { fill: #333; font-size: 10px; text-anchor: middle; background: #fff; }
+      .title      { font-weight: 700; font-size: 15px; fill: #1a2733; }
+      .caption    { fill: #555; font-size: 12px; text-anchor: middle; }
+    </style>
+  </defs>
+  <text x="450" y="24" text-anchor="middle" class="title">Underlay — eBGP (default) or IS-IS (optional)</text>
+
+  <!-- Spines -->
+  <rect x="230" y="70" width="140" height="55" rx="6" class="role-spine"/>
+  <text x="300" y="90" class="nodelbl">spine1</text>
+  <text x="300" y="108" class="nodelbl" font-size="11" font-weight="400">Loopback0 192.168.255.1</text>
+
+  <rect x="530" y="70" width="140" height="55" rx="6" class="role-spine"/>
+  <text x="600" y="90" class="nodelbl">spine2</text>
+  <text x="600" y="108" class="nodelbl" font-size="11" font-weight="400">Loopback0 192.168.255.2</text>
+
+  <text x="180" y="98" class="as">AS 65001</text>
+  <text x="720" y="98" class="as">AS 65001</text>
+
+  <!-- Leaves -->
+  <g>
+    <rect x="40"  y="290" width="180" height="55" rx="6" class="role-leaf"/>
+    <text x="130" y="310" class="nodelbl">pe11</text>
+    <text x="130" y="328" class="nodelbl" font-size="11" font-weight="400">Lo0 192.168.255.3</text>
+
+    <rect x="240" y="290" width="180" height="55" rx="6" class="role-leaf"/>
+    <text x="330" y="310" class="nodelbl">pe12</text>
+    <text x="330" y="328" class="nodelbl" font-size="11" font-weight="400">Lo0 192.168.255.4</text>
+
+    <rect x="480" y="290" width="180" height="55" rx="6" class="role-leaf"/>
+    <text x="570" y="310" class="nodelbl">pe21</text>
+    <text x="570" y="328" class="nodelbl" font-size="11" font-weight="400">Lo0 192.168.255.5</text>
+
+    <rect x="680" y="290" width="180" height="55" rx="6" class="role-leaf"/>
+    <text x="770" y="310" class="nodelbl">pe22</text>
+    <text x="770" y="328" class="nodelbl" font-size="11" font-weight="400">Lo0 192.168.255.6</text>
+  </g>
+
+  <text x="130" y="365" class="as">AS 65101</text>
+  <text x="330" y="365" class="as">AS 65102</text>
+  <text x="570" y="365" class="as">AS 65103</text>
+  <text x="770" y="365" class="as">AS 65104</text>
+
+  <!-- Underlay P2P links -->
+  <g>
+    <line x1="290" y1="125" x2="130" y2="290" class="underlay"/>
+    <line x1="300" y1="125" x2="330" y2="290" class="underlay"/>
+    <line x1="315" y1="125" x2="570" y2="290" class="underlay"/>
+    <line x1="330" y1="125" x2="770" y2="290" class="underlay"/>
+
+    <line x1="570" y1="125" x2="130" y2="290" class="underlay"/>
+    <line x1="585" y1="125" x2="330" y2="290" class="underlay"/>
+    <line x1="600" y1="125" x2="570" y2="290" class="underlay"/>
+    <line x1="615" y1="125" x2="770" y2="290" class="underlay"/>
+  </g>
+
+  <!-- Link IP examples -->
+  <text x="215" y="215" class="link-lbl">172.31.255.0/31</text>
+  <text x="380" y="215" class="link-lbl">172.31.255.4/31</text>
+  <text x="510" y="215" class="link-lbl">172.31.255.8/31</text>
+  <text x="675" y="215" class="link-lbl">172.31.255.12/31</text>
+
+  <!-- Caption -->
+  <text x="450" y="415" class="caption">All P2P links use /31 from 172.31.255.0/24. Loopback0 addresses are advertised via `redistribute connected`</text>
+  <text x="450" y="432" class="caption">route-map matching `PL-LOOPBACKS-EVPN-OVERLAY` so leaves learn each other's EVPN next-hops.</text>
+  <text x="450" y="460" class="caption" font-style="italic">IS-IS alternative: same physical topology, `router isis EVPN_UNDERLAY` area 49.0001 level-2 replaces eBGP.</text>
+</svg>

--- a/docs/gnmic-deployment-guide/_abbreviations.md
+++ b/docs/gnmic-deployment-guide/_abbreviations.md
@@ -1,0 +1,26 @@
+*[BGP]: Border Gateway Protocol
+*[EVPN]: Ethernet VPN (RFC7432, RFC8365)
+*[VXLAN]: Virtual eXtensible LAN
+*[VNI]: VXLAN Network Identifier
+*[L2VNI]: Layer 2 VXLAN Network Identifier
+*[VTEP]: VXLAN Tunnel Endpoint
+*[ESI]: Ethernet Segment Identifier
+*[IRB]: Integrated Routing and Bridging
+*[VRF]: Virtual Routing and Forwarding
+*[gNMI]: gRPC Network Management Interface
+*[gRPC]: Google RPC
+*[YANG]: Yet Another Next Generation (RFC 7950 modeling language)
+*[PromQL]: Prometheus Query Language
+*[TSDB]: Time-Series Database
+*[AVD]: Arista Validated Designs
+*[MLAG]: Multi-Chassis Link Aggregation
+*[LACP]: Link Aggregation Control Protocol
+*[MST]: Multiple Spanning Tree
+*[RPC]: Remote Procedure Call
+*[RD]: Route Distinguisher
+*[RT]: Route Target
+*[AFI]: Address Family Identifier
+*[SAFI]: Subsequent Address Family Identifier
+*[BFD]: Bidirectional Forwarding Detection
+*[POD]: Point of Delivery
+*[MTU]: Maximum Transmission Unit

--- a/docs/gnmic-deployment-guide/exploring-the-lab.md
+++ b/docs/gnmic-deployment-guide/exploring-the-lab.md
@@ -1,0 +1,547 @@
+# **Exploring the Lab**
+
+The reference sections above describe *what* the lab is. The subsections below are hands-on tasks that walk you through *how to use it* — one section per pipeline layer, ordered the way you actually work with them.
+
+Each task follows the same shape: **Task** → **Expected**.
+
+!!! info "Environment"
+    All `G` / `GO` commands below wrap the `gnmic` and `gnoic` binaries baked into the collector container. Set these aliases once in your host terminal:
+
+    ```bash
+    alias G='docker exec -i gnmic /app/gnmic -u arista -p arista --insecure'
+    alias GO='docker exec -i gnmic /app/gnoic -u arista -p arista --insecure'
+    ```
+
+    Zsh treats `[name=…]` as a filename glob and errors with `zsh: no matches found` if the path is unquoted. All `--path` arguments below are single-quoted for that reason.
+
+    Shells: host terminal (runs `G` / `GO`), switch CLI (`docker exec -it <host> Cli`), switch Linux shell (`docker exec -it <host> bash`), client (`docker exec -it client1 bash`). `<host>` is one of `spine1`, `spine2`, `pe11`, `pe12`, `pe21`, `pe22`.
+
+## **gNMI Read**
+
+The read-side of gNMI: discover what the switch supports, fetch state on demand, and pick the right YANG origin.
+
+### **Capabilities**
+
+Every gNMI client should call `Capabilities` once on connect to know what the server can do. It returns the gNMI version, supported wire encodings, and the YANG models the switch has loaded.
+
+**Task.**
+
+```bash
+G -a spine1:6030 capabilities | less
+```
+
+**Expected.** A `gNMI version:` line (≥ 0.7), a `supported encodings:` list (JSON, JSON_IETF, ASCII, PROTO), and a long list of `name: <model>, version: ..., organization: ...` entries covering both OpenConfig (`openconfig-*`) and Arista-specific augments (`arista-*`).
+
+### **Get: paths, types, and the cli origin**
+
+`Get` is a one-shot read. `--path` can be repeated for multi-path reads in a single RPC. `--type` filters what part of the tree to return. The `cli:` origin returns the same JSON EOS produces via `show ... | json` — handy when the OpenConfig walk is verbose.
+
+**Task.** Single path, multi-path, type filter, and the cli origin:
+
+```bash
+G -a spine1:6030 get --path '/system/state/hostname'
+
+G -a spine1:6030 get \
+  --path '/system/state/hostname' \
+  --path '/system/state/boot-time' \
+  --path '/system/state/current-datetime'
+
+G -a spine1:6030 get --type CONFIG --path '/interfaces/interface[name=Ethernet1]/config'
+G -a spine1:6030 get --type STATE  --path '/interfaces/interface[name=Ethernet1]/state'
+G -a spine1:6030 get --type OPERATIONAL --path '/interfaces/interface[name=Ethernet1]/state'
+
+G -a spine1:6030 --gzip get \
+  --path 'cli:/show bgp evpn summary' \
+  --path 'cli:/show vxlan vni'
+```
+
+**Expected.** JSON payloads for each path. `CONFIG` returns intended configuration only; `STATE` returns operational state (session-state, message counters); `OPERATIONAL` returns only runtime-computed values (a subset of state); the default returns everything. The `cli:` calls return the same shape as `show ... | json`.
+
+### **Origins: OpenConfig vs eos_native vs cli**
+
+Every path in gNMI carries an origin qualifier that tells the server which YANG tree to walk. Same underlying facts can appear under multiple origins with different shape and coverage.
+
+**Task.** Same concept via three origins.
+
+```bash
+G -a spine1:6030 get --path '/components/component[name=CPU0]/cpu/utilization/state'
+G -a spine1:6030 get --path 'eos_native:/Kernel/sysinfo'
+G -a spine1:6030 get --path 'cli:/show version'
+```
+
+**Expected.**
+
+- **OpenConfig** returns a well-defined `avg-usage-percent` structure — vendor-neutral, portable, but coverage lags real features.
+- **`eos_native:`** returns the raw Sysdb view with load averages and process counts — Arista-specific but complete. If empty, the switch is missing `provider eos-native` under `management api gnmi`.
+- **`cli:`** returns the JSON EOS produces for `show version` — a familiar shape when you need a specific CLI's output.
+
+Rule of thumb: prefer OpenConfig for portability, drop to `eos_native:` when OpenConfig has a gap, use `cli:` for one-off diagnostics.
+
+
+## **gNMI Subscribe & Stream Modes**
+
+`Subscribe` is the RPC that powers streaming telemetry. The subscription's *stream mode* governs when the server pushes updates: on a fixed cadence, only on value change, or a mix picked per-leaf.
+
+![Stream mode timing](../assets/img/gnmic-pg-stream-modes.svg)
+
+### **ONCE vs STREAM**
+
+**Task.**
+
+```bash
+G -a spine1:6030 subscribe --mode once --path '/system/state'
+G -a spine1:6030 subscribe --path '/system/state' --sample-interval 10s
+```
+Ctrl-C after 30s on the stream.
+
+**Expected.** `once` returns one batch and exits. `stream` prints a sync marker, then a fresh payload every 10s.
+
+### **SAMPLE**
+
+The server pushes on every interval regardless of value change. Right for counters, gauges, temperatures. Wrong for enums.
+
+**Task.**
+
+```bash
+G -a spine1:6030 subscribe \
+  --stream-mode sample --sample-interval 5s \
+  --path '/interfaces/interface[name=Ethernet1]/state/counters/in-octets'
+```
+
+**Expected.** One update every 5s, `in-octets` monotonically increasing.
+
+!!! note "Interval selection"
+    Pick the interval by the leaf's rate of change and the alerting latency you need. Counters 5–30s; slow-moving inventory 60s+. Stream cost scales with `paths × interfaces × sample_rate` — do not set 1s intervals on wildcarded subtrees.
+
+### **ON_CHANGE (with and without heartbeat)**
+
+The server pushes only when the value changes. Right for enums and event-like state (link up/down, BGP session state). Wrong for counters. `--heartbeat-interval` adds a periodic "still alive" push so silence doesn't get mistaken for a dead switch.
+
+**Task.** Correct use — link state:
+
+```bash
+G -a spine1:6030 subscribe --stream-mode on_change \
+  --path '/interfaces/interface[name=Ethernet1]/state/oper-status'
+```
+
+In a second terminal:
+```bash
+docker exec -it spine1 Cli
+spine1# configure
+spine1(config)# interface Ethernet1
+spine1(config-if-Et1)# shutdown
+spine1(config-if-Et1)# no shutdown
+```
+
+**Expected.** Sync marker, then silence, then two events (`DOWN`, `UP`) firing within milliseconds of each CLI command.
+
+**Task.** Wrong use — counters:
+
+```bash
+G -a spine1:6030 subscribe --stream-mode on_change \
+  --path '/interfaces/interface[name=Ethernet1]/state/counters/in-octets'
+```
+
+**Expected.** A flood of updates — every packet ticks the counter. Do not do this in production.
+
+**Task.** ON_CHANGE + heartbeat — best of both worlds:
+
+```bash
+G -a spine1:6030 subscribe --stream-mode on_change \
+  --heartbeat-interval 20s \
+  --path '/interfaces/interface[name=Ethernet1]/state/oper-status' \
+  --format event
+```
+
+Let it run for a minute. Then bounce the link from a second terminal.
+
+**Expected.** One event on startup, then a heartbeat every 20s carrying the same value. When you bounce the link, an immediate event arrives on top of the heartbeat cycle.
+
+!!! note "Arista gotcha — `suppress-redundant` is silently ignored"
+    gnmic accepts a `suppress-redundant: true` flag that's supposed to skip a sample if the value hasn't changed since the previous one. On Arista EOS (Octa) that flag is accepted and ignored (Bug 779417) — the server pushes on every sample regardless. The only real lever to cut SAMPLE volume is the interval itself.
+
+### **TARGET_DEFINED**
+
+Let EOS pick the mode per leaf across a subtree. Convenient default for broad reads; less predictable than explicit modes.
+
+**Task.**
+
+```bash
+G -a spine1:6030 subscribe --stream-mode target_defined --sample-interval 5s \
+  --path '/interfaces/interface[name=Ethernet1]/state' \
+  --format event
+```
+
+**Expected.** EOS auto-splits — `oper-status` and `admin-status` land on ON_CHANGE (initial value then silence), counters (`in-octets`, `out-octets`) land on SAMPLE at 5s. Convenient for broad subtrees; less predictable than the explicit modes.
+
+### **Mixed-mode subscription (production pattern)**
+
+Real deployments care about both alerting latency *and* steady-state observability, so they combine modes inside a single SubscriptionList: `on_change` on state leaves, `sample` on counters, one gRPC connection carrying both. This is the shape you'll write when adding a subscription to `clab/gnmic.yml`.
+
+**Task.** The lab ships an example combo block in `clab/gnmic-stream-modes-demo.yml`. Extract just the mixed-mode block:
+
+```yaml
+intf_mixed_modes:
+  subscription-mode: stream
+  paths:
+    # State transitions — react instantly.
+    - path: /interfaces/interface[name=Ethernet1]/state/oper-status
+      stream-mode: on_change
+      heartbeat-interval: 60s
+    # Counters — sample every 5s.
+    - path: /interfaces/interface[name=Ethernet1]/state/counters/in-octets
+      stream-mode: sample
+      sample-interval: 5s
+    - path: /interfaces/interface[name=Ethernet1]/state/counters/out-octets
+      stream-mode: sample
+      sample-interval: 5s
+```
+
+**Expected.** One SubscriptionList sent to the switch, three paths inside it, each with its own `stream-mode`. On the wire this is one gRPC stream carrying all three. The switch pushes the state leaf on transitions (with a 60s heartbeat), and pushes both counter leaves every 5s.
+
+### **Comparing all modes side-by-side**
+
+The `clab/gnmic-stream-modes-demo.yml` config subscribes to the *same path* in SAMPLE, ON_CHANGE, ON_CHANGE+heartbeat, TARGET_DEFINED, and the mixed-mode combo simultaneously. Writes events to stdout so you can watch each mode fire in real time.
+
+**Task.** Run the demo in an ephemeral collector container that shares the persistent `gnmic` container's network, then bounce `spine1:Ethernet1` from a second terminal.
+
+```bash
+cd ~/gnmic-prometheus-grafana
+docker run --rm -it \
+  --network container:gnmic \
+  -v $(pwd)/clab/gnmic-stream-modes-demo.yml:/cfg.yml:ro \
+  ghcr.io/openconfig/gnmic:latest \
+  --config /cfg.yml subscribe
+```
+
+Second terminal:
+
+```
+docker exec -it spine1 Cli
+spine1# configure
+spine1(config)# interface Ethernet1
+spine1(config-if-Et1)# shutdown
+spine1(config-if-Et1)# no shutdown
+```
+
+**Expected.**
+
+- **SAMPLE** fires every 5s regardless of the flap
+- **ON_CHANGE** fires only on the two transitions
+- **ON_CHANGE + heartbeat** fires on the transitions and every 20s in between
+- **TARGET_DEFINED** fires on transitions for `oper-status` and every 5s for the counters
+- **Mixed-mode** prints one on_change stream for state and one 5s sample stream for counters
+
+### **Counting event volume — the on_change payoff**
+
+The reason ON_CHANGE exists is bandwidth. On a stable link the difference is dramatic.
+
+**Task.** Run each for 60s on a stable link and count events:
+
+```bash
+timeout 60 G -a spine1:6030 subscribe --mode stream --stream-mode sample --sample-interval 5s \
+  --path '/interfaces/interface[name=Ethernet1]/state/oper-status' --format event 2>/dev/null \
+  | grep -c '"values"'
+# → ~12 events
+
+timeout 60 G -a spine1:6030 subscribe --mode stream --stream-mode on_change \
+  --path '/interfaces/interface[name=Ethernet1]/state/oper-status' --format event 2>/dev/null \
+  | grep -c '"values"'
+# → 1 event
+```
+
+**Expected.** 12× traffic reduction on the stable path. This is why real dashboards mix modes — ON_CHANGE for enums that rarely fire, SAMPLE for counters where every sample is meaningful.
+
+
+## **gNMI Write**
+
+The write-side of gNMI: modify configuration in atomic transactions.
+
+### **Set: update, replace, delete**
+
+`Set` is atomic per-RPC — everything in one Set request commits or nothing does. Three sub-operations: `--update` (merge), `--replace` (subtree overwrite), `--delete` (remove).
+
+**Task.**
+
+```bash
+# update (merge)
+G -a spine1:6030 set \
+  --update-path '/interfaces/interface[name=Loopback0]/config/description' \
+  --update-value 'set-via-gnmi'
+
+# verify from the CLI
+docker exec -it spine1 Cli -c 'show interfaces Loopback0 | include Description'
+
+# delete
+G -a spine1:6030 set \
+  --delete '/interfaces/interface[name=Loopback0]/config/description'
+
+# replace (full subtree overwrite — anything omitted is deleted)
+G -a spine1:6030 set \
+  --replace-path '/interfaces/interface[name=Loopback0]/config' \
+  --replace-value '{"name":"Loopback0","enabled":true,"description":"replaced-subtree"}'
+```
+
+**Expected.** `SetResponse` with a success timestamp for each operation. Update merges into the config leaf. Delete removes it. Replace overwrites the entire subtree.
+
+!!! note "Update vs replace"
+    Prefer `update` unless you deliberately want a subtree overwrite. `replace` silently deletes any leaves you omitted from the payload — very easy to accidentally strip config you didn't intend to touch.
+
+!!! note "Concurrent Set is not atomic across RPCs"
+    Two operators writing the same leaf simultaneously race — last-writer-wins. In production, serialize Sets through a single client (or use CVP/AVD which coordinates).
+
+
+## **Configuring the Collector**
+
+Everything Prometheus stores comes from a subscription in `clab/gnmic.yml`. Reading, editing, and introspecting that file is the day-to-day of running the pipeline.
+
+### **Reading the subscription config**
+
+**Task.** Open the file in a pager and answer these questions from the config:
+
+```bash
+less clab/gnmic.yml
+```
+
+- Which subscription produces the metric `gnmic_bgp_neighbors_session_state`?
+- What sample interval does that subscription use?
+- `cpu` and `cpu_load_avg` are two different subscriptions — what origin does each use?
+- Which subscription produces `gnmic_intf_ctrs_in_octets`?
+
+Then verify against what the collector is actually producing:
+
+```bash
+docker exec gnmic wget -qO- localhost:9273/metrics \
+  | grep -o 'subscription_name="[^"]*"' | sort -u
+```
+
+**Expected.** 17 distinct subscription names — one per block in `clab/gnmic.yml`. Answers from the file: `bgp_neighbors` / 5s / `cpu` uses OpenConfig `components/component/cpu`, `cpu_load_avg` uses `eos_native:/Kernel/sysinfo` / `intf_ctrs`.
+
+### **Adding your own subscription**
+
+**Task.** Add a new persistent subscription for LLDP neighbors.
+
+Append to `clab/gnmic.yml`:
+
+```yaml
+  lldp_neighbors:
+    paths:
+      - /lldp/interfaces/interface[name=*]/neighbors/neighbor/state
+    mode: stream
+    stream-mode: sample
+    sample-interval: 15s
+```
+
+Reload the collector — the file is bind-mounted from the host (`clab/topology.clab.yml`), so editing on the host and restarting the container is enough:
+
+```bash
+docker restart gnmic
+docker exec gnmic wget -qO- http://localhost:9273/metrics | grep gnmic_lldp_neighbors | head -5
+```
+
+**Expected.** `gnmic_lldp_neighbors_*` metrics appear within 15s of restart, one per LLDP neighbor per interface, tagged with `source`, `interface_name`, and neighbor identity labels.
+
+For a one-off subscribe with no persistent state and no restart — useful when iterating on a path — drive `gnmic subscribe` directly from the CLI:
+
+```bash
+G -a spine1:6030 subscribe \
+  --path '/system/state/hostname' \
+  --stream-mode sample --sample-interval 10s \
+  --format event
+```
+
+This prints events to your terminal only — nothing lands in Prometheus. Ctrl-C to stop.
+
+### **Introspecting subscriptions from the switch**
+
+Every gNMI server tracks the subscriptions currently open against it. The fastest way to catch "I think I disabled that subscription but it's still running" is to ask the switch what the collector is asking for.
+
+**Task.**
+
+```bash
+G -a spine1:6030 get --path '/telemetry-system/subscriptions'
+```
+
+**Expected.** One connected client (the gnmic container's mgmt IP `172.144.100.200`) with 17 SubscriptionList entries — one per subscription in `clab/gnmic.yml`. Each entry lists paths, stream mode, sample interval. If a subscription you thought you removed still shows up, the collector didn't restart cleanly.
+
+### **Proving the processors reshape metrics**
+
+The event processor chain (`extract-vlan-id` → `drop-gr` → `trim-prefixes` → `bounce-map` → `eos-version`) is why a switch's raw YANG update becomes a clean Prometheus metric. Watch the transformation happen.
+
+**Task.** Compare the raw event to the exported metric for the same leaf.
+
+Raw event (before processors):
+
+```bash
+G -a spine1:6030 subscribe \
+  --path '/interfaces/interface[name=Ethernet1]/state/oper-status' \
+  --stream-mode sample --sample-interval 5s --format event
+```
+
+The `values` field will contain `{"/interfaces/interface/state/oper-status": "UP"}` — long path, string value.
+
+Now the exported Prometheus metric (after processors):
+
+```bash
+docker exec gnmic wget -qO- localhost:9273/metrics \
+  | grep 'gnmic_intf_oper_state_oper_status{source="spine1",interface_name="Ethernet1"'
+```
+
+**Expected.** Metric name is short (`gnmic_intf_oper_state_oper_status`), value is numeric (`1`). Two processors made that happen: `trim-prefixes` collapsed the long path to just the leaf, `bounce-map` replaced `UP` → `1`.
+
+Find the other three processors' work in the metrics dump:
+
+```bash
+# extract-vlan-id — pulled the VLAN id into a label
+docker exec gnmic wget -qO- localhost:9273/metrics | grep 'vlan_id=' | head -3
+
+# eos-version — normalised "EOS" → "eos"
+docker exec gnmic wget -qO- localhost:9273/metrics | grep 'gnmic_show_ver_version'
+
+# drop-gr — no colliding graceful-restart metrics zeroing out the real pfxRcd counters
+docker exec gnmic wget -qO- localhost:9273/metrics | grep -E 'received_prefixes|_pfxRcd' | head -5
+```
+
+**Expected.** VLAN metrics carry a `vlan_id="<num>"` label, version metrics show lowercase `"eos"`, and BGP received-prefix counters show real non-zero values (compare against `show ip bgp summary` on a spine to confirm).
+
+!!! note "Processor order matters"
+    `drop-gr` runs *before* `trim-prefixes` on purpose. If `trim-prefixes` collapsed both `.../graceful-restart/state/pfxRcd` and the real `.../state/pfxRcd` to the same metric name first, they'd collide and one would silently zero the other. See the inline comment in `clab/gnmic.yml`.
+
+
+## **Metrics in Prometheus**
+
+Once gnmic exports metrics, Prometheus scrapes them every 5s and stores the time-series. The next exercise proves the data actually makes it there and lets you follow a single leaf across every hop.
+
+### **Tracing a metric end-to-end (four altitudes)**
+
+**Task.** Follow `Ethernet1 oper-status on spine1` from the switch all the way to the Grafana panel.
+
+**Layer 1 — raw gNMI on the switch.** What the switch actually reports:
+
+```bash
+G -a spine1:6030 get --path '/interfaces/interface[name=Ethernet1]/state/oper-status'
+```
+
+You'll see `oper-status: "UP"` — a string value. Everything downstream is derived from this shape.
+
+**Layer 2 — gnmic's Prometheus exporter.** gnmic subscribes to the same path and converts the notification to Prometheus format on `:9273`. The endpoint isn't published to the host, so exec into the container:
+
+```bash
+docker exec gnmic wget -qO- localhost:9273/metrics \
+  | grep 'gnmic_intf_oper_state_oper_status{' \
+  | grep 'source="spine1"' \
+  | grep 'interface_name="Ethernet1"'
+```
+
+Expected shape:
+
+```
+gnmic_intf_oper_state_oper_status{interface_name="Ethernet1", source="spine1", subscription_name="intf_oper_state"} 1 <timestamp>
+```
+
+Two things changed vs. Layer 1: the value is `1` (not `"UP"`) — that's `bounce-map`. The metric name is short — that's `trim-prefixes`.
+
+**Layer 3 — Prometheus HTTP API.** Prometheus scraped that endpoint within the last 5s. Ask Prometheus directly:
+
+```bash
+docker exec prometheus wget -qO- \
+  'http://localhost:9090/api/v1/query?query=gnmic_intf_oper_state_oper_status{source="spine1",interface_name="Ethernet1"}'
+```
+
+The `.data.result[0].value` field is `[<epoch>, "1"]` — the same `1`, now stored in the TSDB with a timestamp.
+
+**Layer 4 — Grafana.** Open `http://<host>:3001`, navigate to the `interface-stats` dashboard, find the *Interface Admin Status Table* panel, filter for `source=spine1` and look up `Ethernet1`. Value shows **Up** (Grafana applies a value mapping `1 → Up`, `0 → Down` for display).
+
+**Expected.** The same underlying state (`"UP"` → `1` → `1` → `Up`) at all four layers, one hop apart. If a hop returns nothing, that's where the bug lives — the pipeline is fully observable end-to-end.
+
+
+## **Panels in Grafana**
+
+Grafana is the visualization layer. Adding a panel is cheap once the pipeline is flowing — the metric is already scraped, you just have to query it.
+
+### **Authoring a Grafana panel and persisting it**
+
+Panels created in the UI live only until the container is restarted. To make a new panel survive `make stop && make start`, save it to the provisioning directory that's bind-mounted from the host.
+
+**Task.** Build a fabric-wide ingress-bps panel, then persist it.
+
+1. Open `http://<host>:3001`, log in as `arista`/`arista` (or use anonymous Admin).
+2. New dashboard → Add visualization → `prometheus` datasource.
+3. Query:
+
+    ```promql
+    sum by (source) (rate(gnmic_intf_ctrs_in_octets_total[1m])) * 8
+    ```
+
+4. Panel title *Aggregate fabric ingress (bps)*, unit `bits/sec`. Legend `{{source}}`. Save.
+
+**Expected.** A time-series with one line per switch. Idle lab hovers near zero; run `iperf3` between clients to see it move.
+
+**Persist the dashboard so it survives a rebuild:**
+
+- Dashboard settings (gear icon) → **JSON Model** → **Copy to clipboard**.
+- On your host:
+
+    ```bash
+    cat > clab/grafana/provisioning/dashboards/fabric-ingress.json <<'EOF'
+    (paste)
+    EOF
+    docker restart grafana
+    ```
+
+- Wait ~10s, refresh the browser. Your dashboard is now provisioned — it survives `make stop && make start` (even with `--reconfigure`) because the folder is bind-mounted from the host.
+
+**Expected.** The provisioning file appears in the container within seconds of the restart, and Grafana's dashboard list shows it under whatever folder the `dashboards.yml` provisioner targets.
+
+!!! note "You did not touch gnmic.yml or prometheus.yml"
+    Only the Grafana JSON changed — the metric was already being subscribed, exported, and scraped. That's the whole point of the pipeline: once the data is flowing, adding visualizations is cheap.
+
+### **Interface bounce → end-to-end latency**
+
+**Task.** Measure the delay between a link event on the switch and the value change in Prometheus.
+
+```bash
+# Terminal 1 — watcher
+while true; do
+  curl -s 'http://<host>:9090/api/v1/query?query=gnmic_intf_oper_state_oper_status{source="spine1",interface_name="Ethernet1"}' \
+    | python3 -c 'import sys, json; d=json.load(sys.stdin)["data"]["result"]; print(d[0]["value"] if d else "no data")'
+  sleep 0.5
+done
+
+# Terminal 2 — bounce
+date +%s.%N && docker exec spine1 Cli -c 'enable' -c 'configure' -c 'interface Ethernet1' -c 'shutdown'
+```
+
+**Expected.** The watcher prints `1` steadily, then `0` within ~1–2 seconds (5s subscription sample + 5s Prometheus scrape; typically well under 5s because they align).
+
+
+---
+
+**Previous:** [← Telemetry Stack](telemetry-stack.md) &nbsp;·&nbsp; **Next:** [Troubleshooting →](troubleshooting.md) &nbsp;·&nbsp; [Back to guide index](index.md)
+
+*[BGP]: Border Gateway Protocol
+*[EVPN]: Ethernet VPN (RFC7432, RFC8365)
+*[VXLAN]: Virtual eXtensible LAN
+*[VNI]: VXLAN Network Identifier
+*[L2VNI]: Layer 2 VXLAN Network Identifier
+*[VTEP]: VXLAN Tunnel Endpoint
+*[ESI]: Ethernet Segment Identifier
+*[IRB]: Integrated Routing and Bridging
+*[VRF]: Virtual Routing and Forwarding
+*[gNMI]: gRPC Network Management Interface
+*[gRPC]: Google RPC
+*[YANG]: Yet Another Next Generation (RFC 7950 modeling language)
+*[PromQL]: Prometheus Query Language
+*[TSDB]: Time-Series Database
+*[AVD]: Arista Validated Designs
+*[MLAG]: Multi-Chassis Link Aggregation
+*[LACP]: Link Aggregation Control Protocol
+*[MST]: Multiple Spanning Tree
+*[RPC]: Remote Procedure Call
+*[RD]: Route Distinguisher
+*[RT]: Route Target
+*[AFI]: Address Family Identifier
+*[SAFI]: Subsequent Address Family Identifier
+*[BFD]: Bidirectional Forwarding Detection
+*[POD]: Point of Delivery
+*[MTU]: Maximum Transmission Unit

--- a/docs/gnmic-deployment-guide/exploring-the-lab.md
+++ b/docs/gnmic-deployment-guide/exploring-the-lab.md
@@ -519,29 +519,4 @@ date +%s.%N && docker exec spine1 Cli -c 'enable' -c 'configure' -c 'interface E
 
 **Previous:** [← Telemetry Stack](telemetry-stack.md) &nbsp;·&nbsp; **Next:** [Troubleshooting →](troubleshooting.md) &nbsp;·&nbsp; [Back to guide index](index.md)
 
-*[BGP]: Border Gateway Protocol
-*[EVPN]: Ethernet VPN (RFC7432, RFC8365)
-*[VXLAN]: Virtual eXtensible LAN
-*[VNI]: VXLAN Network Identifier
-*[L2VNI]: Layer 2 VXLAN Network Identifier
-*[VTEP]: VXLAN Tunnel Endpoint
-*[ESI]: Ethernet Segment Identifier
-*[IRB]: Integrated Routing and Bridging
-*[VRF]: Virtual Routing and Forwarding
-*[gNMI]: gRPC Network Management Interface
-*[gRPC]: Google RPC
-*[YANG]: Yet Another Next Generation (RFC 7950 modeling language)
-*[PromQL]: Prometheus Query Language
-*[TSDB]: Time-Series Database
-*[AVD]: Arista Validated Designs
-*[MLAG]: Multi-Chassis Link Aggregation
-*[LACP]: Link Aggregation Control Protocol
-*[MST]: Multiple Spanning Tree
-*[RPC]: Remote Procedure Call
-*[RD]: Route Distinguisher
-*[RT]: Route Target
-*[AFI]: Address Family Identifier
-*[SAFI]: Subsequent Address Family Identifier
-*[BFD]: Bidirectional Forwarding Detection
-*[POD]: Point of Delivery
-*[MTU]: Maximum Transmission Unit
+--8<-- "gnmic-deployment-guide/_abbreviations.md"

--- a/docs/gnmic-deployment-guide/fabric-configuration.md
+++ b/docs/gnmic-deployment-guide/fabric-configuration.md
@@ -455,29 +455,4 @@ The EVPN overlay is untouched — `show bgp evpn summary` on any leaf still list
 
 **Next:** [Telemetry Stack →](telemetry-stack.md) &nbsp;·&nbsp; [Back to guide index](index.md)
 
-*[BGP]: Border Gateway Protocol
-*[EVPN]: Ethernet VPN (RFC7432, RFC8365)
-*[VXLAN]: Virtual eXtensible LAN
-*[VNI]: VXLAN Network Identifier
-*[L2VNI]: Layer 2 VXLAN Network Identifier
-*[VTEP]: VXLAN Tunnel Endpoint
-*[ESI]: Ethernet Segment Identifier
-*[IRB]: Integrated Routing and Bridging
-*[VRF]: Virtual Routing and Forwarding
-*[gNMI]: gRPC Network Management Interface
-*[gRPC]: Google RPC
-*[YANG]: Yet Another Next Generation (RFC 7950 modeling language)
-*[PromQL]: Prometheus Query Language
-*[TSDB]: Time-Series Database
-*[AVD]: Arista Validated Designs
-*[MLAG]: Multi-Chassis Link Aggregation
-*[LACP]: Link Aggregation Control Protocol
-*[MST]: Multiple Spanning Tree
-*[RPC]: Remote Procedure Call
-*[RD]: Route Distinguisher
-*[RT]: Route Target
-*[AFI]: Address Family Identifier
-*[SAFI]: Subsequent Address Family Identifier
-*[BFD]: Bidirectional Forwarding Detection
-*[POD]: Point of Delivery
-*[MTU]: Maximum Transmission Unit
+--8<-- "gnmic-deployment-guide/_abbreviations.md"

--- a/docs/gnmic-deployment-guide/fabric-configuration.md
+++ b/docs/gnmic-deployment-guide/fabric-configuration.md
@@ -1,0 +1,483 @@
+# **Fabric Configuration**
+
+## **Spine**
+
+!!! info
+    The example Spine configuration snippets below are all taken from `spine1`.
+
+### **Global Defaults (Spine)**
+
+```
+no enable password
+no aaa root
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname om-spine1
+!
+spanning-tree mode mstp
+```
+
+### **Enable Routing (Spine)**
+
+```
+ip routing
+no ip routing vrf MGMT
+```
+
+### **Interfaces (Spine)**
+
+The four downlinks toward the leaves are P2P routed interfaces from the `172.31.255.0/24` underlay pool, each a /31. `Loopback0` is the BGP router-id and next-hop for the EVPN overlay.
+
+```
+interface Ethernet1
+   description P2P_om-pe11_Ethernet1
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 172.31.255.0/31
+!
+interface Ethernet2
+   description P2P_om-pe12_Ethernet1
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 172.31.255.4/31
+!
+interface Loopback0
+   description ROUTER_ID
+   no shutdown
+   ip address 192.168.255.1/32
+!
+interface Management0
+   description OOB_MANAGEMENT
+   no shutdown
+   vrf MGMT
+   ip address 172.144.100.2/24
+```
+
+### **Prefix Lists (Spine)**
+
+Used by the `RM-CONN-2-BGP` route-map to redistribute Loopback0 addresses into the underlay so leaves learn each other's EVPN next-hops.
+
+```
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+```
+
+### **Route Maps (Spine)**
+
+```
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+```
+
+### **BGP: Underlay (Spine)**
+
+eBGP over the P2P interfaces to each leaf. Each leaf has its own ASN (`65101`–`65104`); the spine advertises Loopback0 via `redistribute connected`.
+
+```
+router bgp 65001
+   router-id 192.168.255.1
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.1 remote-as 65101
+   neighbor 172.31.255.1 description om-pe11_Ethernet1
+   neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.5 remote-as 65102
+   neighbor 172.31.255.5 description om-pe12_Ethernet1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+```
+
+### **BGP: Overlay (Spine)**
+
+eBGP EVPN peerings sourced from Loopback0, `ebgp-multihop 3`, and `next-hop-unchanged` so the spine reflects the original next-hop (each leaf's Loopback1 VTEP) rather than rewriting it to its own Loopback0. RT-Constraint (rt-membership AFI) reduces overlay churn.
+
+```
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65101
+   neighbor 192.168.255.3 description om-pe11_Loopback0
+   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.4 remote-as 65102
+   neighbor 192.168.255.4 description om-pe12_Loopback0
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family rt-membership
+      neighbor EVPN-OVERLAY-PEERS activate
+      neighbor EVPN-OVERLAY-PEERS default-route-target only
+```
+
+### **gNMI Server (Spine)**
+
+Two gRPC transports listen: `default` in the default VRF and `MGMT` on `Management0`. The `provider eos-native` line enables the `eos_native:` YANG tree — without it, any subscription with an `eos_native:` prefix comes back empty. Default port is 6030.
+
+```
+management api gnmi
+   transport grpc default
+      notification timestamp send-time
+   !
+   transport grpc MGMT
+      vrf MGMT
+      notification timestamp send-time
+   provider eos-native
+```
+
+## **Leaf (PE)**
+
+!!! info
+    The example Leaf configuration snippets below are all taken from `pe11`.
+
+### **Global Defaults (Leaf)**
+
+Leaves prefer MST with priority 4096 (root-bridge candidate).
+
+```
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname om-pe11
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+```
+
+### **Enable Routing (Leaf)**
+
+```
+ip routing
+no ip routing vrf MGMT
+```
+
+### **Interfaces (Leaf)**
+
+Two uplinks to the spines are routed /31 P2Ps. Two downlinks to servers are LACP members of Port-Channels. `Loopback0` is the router-id and EVPN peering source; `Loopback1` is the VTEP source used by the `Vxlan1` interface.
+
+```
+interface Ethernet1
+   description P2P_om-spine1_Ethernet1
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 172.31.255.1/31
+!
+interface Ethernet2
+   description P2P_om-spine2_Ethernet1
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 172.31.255.3/31
+!
+interface Ethernet3
+   description SERVER_server01_Eth1
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description SERVER_server02_Eth1
+   no shutdown
+   channel-group 4 mode active
+!
+interface Loopback0
+   description ROUTER_ID
+   no shutdown
+   ip address 192.168.255.3/32
+!
+interface Loopback1
+   description VXLAN_TUNNEL_SOURCE
+   no shutdown
+   ip address 192.168.254.3/32
+```
+
+### **Prefix Lists (Leaf)**
+
+Redistributes both the router-id loopback and the VTEP loopback into the underlay so peers can reach the VXLAN tunnel endpoints.
+
+```
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+```
+
+### **Route Maps (Leaf)**
+
+```
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+```
+
+### **BGP: Underlay (Leaf)**
+
+Each leaf peers with both spines (`172.31.255.0`, `172.31.255.2`) at ASN `65001`. `no bgp default ipv4-unicast` keeps the overlay peer-group off the IPv4 AFI so EVPN reachability is not carried in the underlay.
+
+```
+router bgp 65101
+   router-id 192.168.255.3
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.0 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.0 remote-as 65001
+   neighbor 172.31.255.0 description om-spine1_Ethernet1
+   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.2 remote-as 65001
+   neighbor 172.31.255.2 description om-spine2_Ethernet1
+   redistribute connected route-map RM-CONN-2-BGP
+```
+
+### **EVPN Multi-Homing (Leaf)**
+
+Each server-facing Port-Channel is an EVPN Ethernet Segment with an explicit ESI and matching LACP system-id. Both leaves in the POD present the same ESI + system-id per bond, so from the client side the two uplinks look like one MLAG bundle, while from the fabric side the MAC/IP is advertised as reachable via the ES (Type-1 Ethernet A-D routes, Type-2 MAC/IP routes).
+
+```
+interface Port-Channel3
+   description PortChannel3
+   no shutdown
+   switchport trunk allowed vlan 110
+   switchport mode trunk
+   switchport
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0101:0102:0033
+      route-target import 01:01:01:02:00:33
+   lacp system-id 0101.0102.0033
+   spanning-tree portfast
+!
+interface Port-Channel4
+   description PortChannel4
+   no shutdown
+   switchport trunk allowed vlan 111
+   switchport mode trunk
+   switchport
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0101:0102:0044
+      route-target import 01:01:01:02:00:44
+   lacp system-id 0101.0102.0044
+   spanning-tree portfast
+```
+
+### **VXLAN Interface (Leaf)**
+
+Single `Vxlan1` interface sourced from Loopback1, one VLAN-to-VNI mapping per tenant network.
+
+```
+interface Vxlan1
+   description om-pe11_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 10111
+```
+
+### **BGP: Overlay (Leaf)**
+
+Each leaf peers with both spines' Loopback0 in the EVPN AFI. Per-VLAN `rd` and `route-target` under `router bgp` bind each MAC-VRF to its L2VNI.
+
+```
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.1 remote-as 65001
+   neighbor 192.168.255.1 description om-spine1_Loopback0
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description om-spine2_Loopback0
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+```
+
+### **MAC-VRF (Leaf)**
+
+One MAC-VRF per L2VNI. `redistribute learned` triggers Type-2 MAC/IP advertisement whenever the local FDB learns a new address.
+
+```
+   vlan 110
+      rd 192.168.255.3:10110
+      route-target both 10110:10110
+      redistribute learned
+   !
+   vlan 111
+      rd 192.168.255.3:10111
+      route-target both 10111:10111
+      redistribute learned
+```
+
+### **gNMI Server (Leaf)**
+
+Same shape as the spine — two transports, `provider eos-native` for the `eos_native:` tree.
+
+```
+management api gnmi
+   transport grpc default
+      notification timestamp send-time
+   !
+   transport grpc MGMT
+      vrf MGMT
+      notification timestamp send-time
+   provider eos-native
+```
+
+## **Underlay Variant: IS-IS**
+
+!!! info
+    Deploy this variant with `ansible-playbook playbooks/fabric-deploy-config.yaml -e underlay_routing_protocol=isis`. In this build the IS-IS blocks below **replace** the [`BGP: Underlay (Spine)`](#bgp-underlay-spine) and [`BGP: Underlay (Leaf)`](#bgp-underlay-leaf) sections above; everything else (interfaces, loopbacks, EVPN overlay peerings, VXLAN, MAC-VRF) is identical to the eBGP variant. The knobs come from `group_vars/OM_FABRIC.yaml` (`isis_area_id: 49.0001`, `isis_default_is_type: level-2`, `isis_advertise_passive_only: false`) and are inert when `underlay_routing_protocol: ebgp`.
+
+    The AVD-generated IS-IS instance is named `EVPN_UNDERLAY` — that is the exact string the [`isis_adjacencies` subscription](telemetry-stack.md#subscriptions-gnmic) targets in `clab/gnmic.yml`.
+
+### **IS-IS Underlay (Spine)**
+
+Level-2, area `49.0001`. `Loopback0` is passive so the router-id is advertised without forming an adjacency on it, and each P2P uplink is a point-to-point IS-IS interface. `authentication mode md5` uses the same key as the eBGP-underlay password so the two variants stay swap-compatible.
+
+```
+router isis EVPN_UNDERLAY
+   net 49.0001.0000.0000.0001.00
+   is-type level-2
+   router-id ipv4 192.168.255.1
+   log-adjacency-changes
+   no hello padding
+   authentication mode md5
+   authentication key 7 <redacted>
+   !
+   address-family ipv4 unicast
+      maximum-paths 4
+!
+interface Loopback0
+   isis enable EVPN_UNDERLAY
+   isis passive
+!
+interface Ethernet1
+   isis enable EVPN_UNDERLAY
+   isis network point-to-point
+   isis metric 50
+!
+interface Ethernet2
+   isis enable EVPN_UNDERLAY
+   isis network point-to-point
+   isis metric 50
+```
+
+The spine still runs `router bgp 65001` for the [EVPN overlay](#bgp-overlay-spine) — only the underlay peer-group (`IPv4-UNDERLAY-PEERS`) and its neighbors disappear. `redistribute connected` is not needed either; IS-IS floods Loopback0 directly.
+
+### **IS-IS Underlay (Leaf)**
+
+Same pattern. The NET's system-id encodes the AVD node ID (`pe11 → id 1`, encoded as `0000.0000.1001`). Both Loopbacks are passive so they advertise without adjacency; the two spine-facing uplinks form point-to-point Level-2 adjacencies.
+
+```
+router isis EVPN_UNDERLAY
+   net 49.0001.0000.0000.1001.00
+   is-type level-2
+   router-id ipv4 192.168.255.3
+   log-adjacency-changes
+   no hello padding
+   authentication mode md5
+   authentication key 7 <redacted>
+   !
+   address-family ipv4 unicast
+      maximum-paths 4
+!
+interface Loopback0
+   isis enable EVPN_UNDERLAY
+   isis passive
+!
+interface Loopback1
+   isis enable EVPN_UNDERLAY
+   isis passive
+!
+interface Ethernet1
+   isis enable EVPN_UNDERLAY
+   isis network point-to-point
+   isis metric 50
+!
+interface Ethernet2
+   isis enable EVPN_UNDERLAY
+   isis network point-to-point
+   isis metric 50
+```
+
+`Loopback1` (the VTEP source) is also injected into IS-IS as passive — without this, remote VTEPs would be unreachable and Type-2 MAC/IP routes would install with an unresolvable next-hop.
+
+### **Verifying the underlay swap**
+
+On any device:
+
+```
+show isis neighbors
+show isis interface brief
+show ip route isis
+```
+
+And from the collector side, the [`isis_adjacencies`](telemetry-stack.md#subscriptions-gnmic) subscription starts returning notifications (it's silent in the eBGP variant):
+
+```bash
+docker exec -it gnmic gnmic -a spine1:6030 --insecure -u arista -p arista \
+  subscribe --path "/network-instances/network-instance[name=default]/protocols/protocol[name=EVPN_UNDERLAY]/isis" --mode once
+```
+
+The EVPN overlay is untouched — `show bgp evpn summary` on any leaf still lists the same two spine peers, and the L3 Telemetry dashboard's `bgp_neighbors` panel keeps showing the overlay session state.
+
+
+---
+
+**Next:** [Telemetry Stack →](telemetry-stack.md) &nbsp;·&nbsp; [Back to guide index](index.md)
+
+*[BGP]: Border Gateway Protocol
+*[EVPN]: Ethernet VPN (RFC7432, RFC8365)
+*[VXLAN]: Virtual eXtensible LAN
+*[VNI]: VXLAN Network Identifier
+*[L2VNI]: Layer 2 VXLAN Network Identifier
+*[VTEP]: VXLAN Tunnel Endpoint
+*[ESI]: Ethernet Segment Identifier
+*[IRB]: Integrated Routing and Bridging
+*[VRF]: Virtual Routing and Forwarding
+*[gNMI]: gRPC Network Management Interface
+*[gRPC]: Google RPC
+*[YANG]: Yet Another Next Generation (RFC 7950 modeling language)
+*[PromQL]: Prometheus Query Language
+*[TSDB]: Time-Series Database
+*[AVD]: Arista Validated Designs
+*[MLAG]: Multi-Chassis Link Aggregation
+*[LACP]: Link Aggregation Control Protocol
+*[MST]: Multiple Spanning Tree
+*[RPC]: Remote Procedure Call
+*[RD]: Route Distinguisher
+*[RT]: Route Target
+*[AFI]: Address Family Identifier
+*[SAFI]: Subsequent Address Family Identifier
+*[BFD]: Bidirectional Forwarding Detection
+*[POD]: Point of Delivery
+*[MTU]: Maximum Transmission Unit

--- a/docs/gnmic-deployment-guide/index.md
+++ b/docs/gnmic-deployment-guide/index.md
@@ -787,29 +787,4 @@ Terms used throughout this guide. All are also rendered as hover-tooltips inline
 | YANG | Yet Another Next Generation (RFC 7950 modeling language) |
 
 
-*[BGP]: Border Gateway Protocol
-*[EVPN]: Ethernet VPN (RFC7432, RFC8365)
-*[VXLAN]: Virtual eXtensible LAN
-*[VNI]: VXLAN Network Identifier
-*[L2VNI]: Layer 2 VXLAN Network Identifier
-*[VTEP]: VXLAN Tunnel Endpoint
-*[ESI]: Ethernet Segment Identifier
-*[IRB]: Integrated Routing and Bridging
-*[VRF]: Virtual Routing and Forwarding
-*[gNMI]: gRPC Network Management Interface
-*[gRPC]: Google RPC
-*[YANG]: Yet Another Next Generation (RFC 7950 modeling language)
-*[PromQL]: Prometheus Query Language
-*[TSDB]: Time-Series Database
-*[AVD]: Arista Validated Designs
-*[MLAG]: Multi-Chassis Link Aggregation
-*[LACP]: Link Aggregation Control Protocol
-*[MST]: Multiple Spanning Tree
-*[RPC]: Remote Procedure Call
-*[RD]: Route Distinguisher
-*[RT]: Route Target
-*[AFI]: Address Family Identifier
-*[SAFI]: Subsequent Address Family Identifier
-*[BFD]: Bidirectional Forwarding Detection
-*[POD]: Point of Delivery
-*[MTU]: Maximum Transmission Unit
+--8<-- "gnmic-deployment-guide/_abbreviations.md"

--- a/docs/gnmic-deployment-guide/index.md
+++ b/docs/gnmic-deployment-guide/index.md
@@ -1,0 +1,815 @@
+# **gNMIc Prometheus Grafana Telemetry Lab**
+
+!!! tip "Deployment Guide"
+    A deep-dive on how the pipeline works, how the fabric is configured, and how to exercise every gNMI RPC and stream mode against the running lab. For the quickstart launch flow, see the [Telemetry lab landing page](../telemetry.md) and the general [aclabs Quickstart](../quickstart.md).
+
+**Deployment guide sections:**
+
+- **[Fabric Configuration](fabric-configuration.md)** — per-role config walkthrough for spines and leaves.
+- **[Telemetry Stack](telemetry-stack.md)** — gNMIc collector, Prometheus, Grafana provisioning.
+- **[Exploring the Lab](exploring-the-lab.md)** — hands-on tasks covering every gNMI RPC, stream mode, and pipeline trace.
+
+---
+
+## **Getting Started**
+
+### **Launch the lab**
+
+[Start the lab :octicons-play-16:](https://labs.arista.com/launch?lab_type=gnmic-prometheus-grafana&origin=tech-lib){ .md-button .md-button--primary target=_blank}
+
+Sign in at [labs.arista.com](https://labs.arista.com/) and click the button above. The lab spins up all six cEOS switches, four Linux clients, and the gNMIc / Prometheus / Grafana containers pre-configured — no manual setup needed.
+
+### **Prerequisites and access**
+
+The lab runs in Arista's cloud lab environment; anyone with an `arista.com` account can launch it. For general environment guidance (Arista account, browser access, ContainerLab basics), see the [aclabs Quickstart](../quickstart.md). No local install is required to follow this guide.
+
+If you want to run the lab on your own machine instead, all files are downloadable from the [lab tarball](https://aristanetworks.github.io/aclabs/lab_archives/gnmic-prometheus-grafana.tar.gz). Local runs are for experienced users comfortable with Containerlab and cEOS-lab image handling.
+
+### **What you should see first**
+
+Once the lab reports ready:
+
+- All 13 containers show `running` (`make inspect` or the Topology Viewer)
+- **Grafana** at `http://<host>:3001` — credentials `arista` / `arista` (anonymous Admin is also enabled). Five dashboards are pre-provisioned; `device-overview` and `interface-stats` populate immediately, `fabric-health` and `evpn-telemetry` populate after the AVD deploy in the next step.
+- **Prometheus** at `http://<host>:9090` — no auth. Try the query `up` — you should see one target (`gnmic:9273`) reporting `1`.
+
+Push the fabric configuration to enable EVPN and the L3 dashboards:
+
+```bash
+ansible-playbook playbooks/fabric-deploy-config.yaml -i inventory.yaml
+```
+
+Once that completes, `l3-telemetry` and `evpn-telemetry` populate. You are now at the starting point for every task in [Exploring the Lab](exploring-the-lab.md).
+
+
+---
+
+## **Overview**
+
+### **Purpose and audience**
+
+This lab demonstrates a full streaming-telemetry pipeline built on top of a small EVPN VXLAN fabric. Six Arista cEOS switches (2 spines and 4 leaves in two PODs) expose network state via gNMI, an OpenConfig gNMIc collector subscribes to a curated set of YANG paths, the events are re-shaped by processors and exported to Prometheus, and Grafana renders the result across five pre-provisioned dashboards.
+
+Streaming telemetry replaces poll-based monitoring (SNMP, CLI screen-scraping) with a subscribe-once model. The switch pushes typed, YANG-schema values at the interval you request, or the moment they change, over gRPC. This lab exercises all four gNMI RPCs (**Capabilities**, **Get**, **Set**, **Subscribe**), all four stream modes (**ONCE**, **SAMPLE**, **ON_CHANGE**, **TARGET_DEFINED**), and both YANG origins (**OpenConfig** and **eos_native**).
+
+The fabric itself is not the focus. It exists so there is something meaningful to measure: BGP sessions to watch flap, EVPN routes to count, interfaces to bounce, VXLAN tunnels to inspect.
+
+### **Design summary**
+
+=== "Physical Topology"
+
+    ![Physical topology](../assets/img/gnmic-pg-topo-physical.svg)
+
+=== "Underlay"
+
+    ![Underlay (eBGP)](../assets/img/gnmic-pg-underlay.svg)
+
+=== "EVPN Overlay"
+
+    ![EVPN overlay](../assets/img/gnmic-pg-overlay.svg)
+
+=== "Telemetry Pipeline"
+
+    ![Telemetry pipeline](../assets/img/gnmic-pg-pipeline.svg)
+
+=== "Summary"
+
+    | Component | Model |
+    |---|---|
+    | Fabric name (AVD) | `OM_FABRIC` |
+    | IPv4 Underlay | eBGP (default) or IS-IS |
+    | EVPN Overlay | eBGP |
+    | MAC-VRF | VLAN-Based |
+    | Multi-Homing | EVPN All-Active (ESI + LACP) |
+    | Overlay Multi-Homing bundles | Port-Channel per client, per PE pair |
+    | Spanning-tree mode | MST (priority 4096 on leaves) |
+    | Fabric MTU | 9214 |
+    | Loopback0 (Router ID) pool | `192.168.255.0/24` |
+    | Loopback1 (VTEP source) pool | `192.168.254.0/24` |
+    | P2P Underlay pool | `172.31.255.0/24` (/31 per link) |
+    | Spine ASN | `65001` |
+    | Leaf ASN scheme | `65101`, `65102`, `65103`, `65104` |
+
+=== "Node IDs"
+
+    | Node | Role | Loopback0 (Router ID) | Loopback1 (VTEP) | ASN |
+    |---|---|---|---|---|
+    | `spine1` | Spine | `192.168.255.1` | — | `65001` |
+    | `spine2` | Spine | `192.168.255.2` | — | `65001` |
+    | `pe11` | Leaf (POD_1) | `192.168.255.3` | `192.168.254.3` | `65101` |
+    | `pe12` | Leaf (POD_1) | `192.168.255.4` | `192.168.254.4` | `65102` |
+    | `pe21` | Leaf (POD_2) | `192.168.255.5` | `192.168.254.5` | `65103` |
+    | `pe22` | Leaf (POD_2) | `192.168.255.6` | `192.168.254.6` | `65104` |
+    | `client1`–`client4` | Servers | — | — | — |
+
+=== "Tenant Networks"
+
+    | VLAN | Name | VNI | Multi-Homed From | Clients |
+    |---|---|---|---|---|
+    | 110 | `Tenant_A_OP_Zone_1` | 10110 | `pe11`+`pe12`, `pe21`+`pe22` | `client1`, `client3` |
+    | 111 | `Tenant_A_OP_Zone_2` | 10111 | `pe11`+`pe12`, `pe21`+`pe22` | `client2`, `client4` |
+
+    Each client is dual-attached (LACP bond) to the two leaves in its POD. On the leaf side each attachment terminates in a Port-Channel with an EVPN Ethernet Segment (ESI + LACP system-id) so both leaves advertise the client's MAC/IP as reachable via the same ES.
+
+
+---
+
+## **Lab Environment**
+
+### **What runs where**
+
+The lab is a Containerlab topology on one management network (`172.144.100.0/24`, VRF `MGMT`). Six cEOS switches carry the fabric; four Linux clients are dual-attached to the leaves; three service containers form the telemetry stack.
+
+| Container | Image | Mgmt IP | Ports exposed to host | Credentials |
+|---|---|---|---|---|
+| `spine1`, `spine2` | `arista/ceos:latest` (tested 4.34.2F) | `.2`, `.3` | none | `arista` / `arista` |
+| `pe11`, `pe12`, `pe21`, `pe22` | `arista/ceos:latest` | `.4`–`.7` | none | `arista` / `arista` |
+| `client1`–`client4` | `ghcr.io/aristanetworks/aclabs/host-ubuntu:rev1.0` | `.8`–`.11` | none | — |
+| `gnmic` | `ghcr.io/openconfig/gnmic:latest` | `.200` | `9273` (in-cluster only) | `arista` / `arista` |
+| `prometheus` | `prom/prometheus:v2.54.1` | `.210` | **`9090` → host** | none |
+| `grafana` | `grafana/grafana:11.2.0` | `.220` | **`3001` → host** | `arista` / `arista` |
+
+Only Grafana and Prometheus publish ports to the host. The `gnmic:9273` `/metrics` endpoint is reachable only from inside the Containerlab network — Prometheus scrapes it there, and to query it from the host you `docker exec` into the `gnmic` container.
+
+### **Underlay variant toggle**
+
+The fabric supports two underlay routing protocols; the EVPN overlay is eBGP in both cases.
+
+| Variant | How to deploy | AVD renders |
+|---|---|---|
+| **eBGP underlay** (default) | `ansible-playbook playbooks/fabric-deploy-config.yaml` | `router bgp` with per-leaf ASNs |
+| **IS-IS underlay** | `ansible-playbook playbooks/fabric-deploy-config.yaml -e underlay_routing_protocol=isis` | `router isis EVPN_UNDERLAY`, level-2, area 49.0001 |
+
+The IS-IS variant enables the `isis_adjacencies` subscription in `clab/gnmic.yml`; in the eBGP build that subscription silently returns no data.
+
+### **Telemetry subscriptions catalog**
+
+All subscriptions run in `stream` mode against every switch. Origin is OpenConfig unless prefixed with `eos_native:`.
+
+| Subscription | Path | Stream Mode | Sample Interval |
+|---|---|---|---|
+| `bgp_neighbors` | `/network-instances/network-instance[name=default]/protocols/protocol[name=BGP]/bgp/neighbors` | sample | 5s |
+| `cpu` | `components/component/cpu` | sample | 5s |
+| `cpu_load_avg` | `eos_native:/Kernel/sysinfo` | sample | 5s |
+| `processes` | `system/processes/process/state` | sample | 15s |
+| `memory` | `components/component/state/memory/`, `system/memory/kernel/state`, `system/memory/state` | sample | 5s |
+| `intf_ctrs` | `/interfaces/interface[name=*]/state/counters` | sample | 5s |
+| `intf_admin_state` | `/interfaces/interface[name=*]/state/admin-status` | sample | 5s |
+| `intf_oper_state` | `/interfaces/interface[name=*]/state/oper-status` | sample | 5s |
+| `intf_config` | `interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/config` | sample | 5s |
+| `show_ver` | `eos_native:/Eos/image` | sample | 60s |
+| `boot_time` | `system/state/boot-time` | sample | 60s |
+| `hardware` | `components/component/state`, `eos_native:/Sysdb/hardware/entmib` | sample | 60s |
+| `isis_adjacencies` | `/network-instances/network-instance[name=default]/protocols/protocol[name=EVPN_UNDERLAY]/isis` | sample | 10s |
+| `mac_table` | `network-instances/network-instance[name=default]/fdb/mac-table/entries/entry` | sample | 30s |
+| `arp` | `/interfaces/interface/subinterfaces/subinterface/ipv4/neighbors/neighbor` | sample | 30s |
+| `vlan_internal` | `eos_native:/Sysdb/bridging/config/vlanConfig` | sample | 30s |
+| `conn_mon` | `arista/connectivity-monitor/clients/client` | sample | 10s |
+
+Each subscription's shape (path, mode, interval) is authored in [`clab/gnmic.yml`](https://github.com/aristanetworks/aclabs/blob/main/labs/gnmic-prometheus-grafana/clab/gnmic.yml). See [Telemetry Stack → gNMIc Collector](telemetry-stack.md#gnmic-collector) for the raw YAML and processor chain that reshapes these into Prometheus metrics.
+
+
+---
+
+## **Appendix**
+
+### **Full spine configuration**
+
+??? details "Complete `spine1` running configuration as rendered by AVD"
+
+    ```
+    !
+    no enable password
+    no aaa root
+    !
+    username arista privilege 15 role network-admin secret sha512 $6$7t1sx38LSYabjfkz$TNsa1HyVX4kehVvqFvJVF1omlYKxUkeAV4AfDlJ3tQnSoR1GfaaaicGyKjVJG/s63wxiTW1zgbchOH2dZ38lH.
+    !
+    vlan internal order ascending range 1006 1199
+    !
+    transceiver qsfp default-mode 4x10G
+    !
+    service routing protocols model multi-agent
+    !
+    hostname om-spine1
+    ip name-server vrf MGMT 1.1.1.1
+    ip name-server vrf MGMT 8.8.8.8
+    !
+    spanning-tree mode mstp
+    !
+    vrf instance MGMT
+    !
+    management api http-commands
+       protocol https
+       protocol https ssl profile eAPI
+       no shutdown
+       !
+       vrf MGMT
+      no shutdown
+    !
+    management api gnmi
+       transport grpc default
+      notification timestamp send-time
+       !
+       transport grpc MGMT
+      vrf MGMT
+      notification timestamp send-time
+       provider eos-native
+    !
+    management security
+       !
+       ssl profile eAPI
+      cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+      certificate eAPI.crt key eAPI.key
+    !
+    interface Ethernet1
+       description P2P_om-pe11_Ethernet1
+       no shutdown
+       mtu 9214
+       no switchport
+       ip address 172.31.255.0/31
+    !
+    interface Ethernet2
+       description P2P_om-pe12_Ethernet1
+       no shutdown
+       mtu 9214
+       no switchport
+       ip address 172.31.255.4/31
+    !
+    interface Ethernet3
+       description P2P_om-pe21_Ethernet1
+       no shutdown
+       mtu 9214
+       no switchport
+       ip address 172.31.255.8/31
+    !
+    interface Ethernet4
+       description P2P_om-pe22_Ethernet1
+       no shutdown
+       mtu 9214
+       no switchport
+       ip address 172.31.255.12/31
+    !
+    interface Loopback0
+       description ROUTER_ID
+       no shutdown
+       ip address 192.168.255.1/32
+    !
+    interface Management0
+       description OOB_MANAGEMENT
+       no shutdown
+       vrf MGMT
+       ip address 172.144.100.2/24
+    !
+    ip routing
+    no ip routing vrf MGMT
+    !
+    ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+       seq 10 permit 192.168.255.0/24 eq 32
+    !
+    ip route vrf MGMT 0.0.0.0/0 172.144.100.1
+    !
+    ntp server vrf MGMT time.google.com prefer
+    !
+    route-map RM-CONN-2-BGP permit 10
+       match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+    !
+    router bfd
+       multihop interval 300 min-rx 300 multiplier 3
+    !
+    router bgp 65001
+       router-id 192.168.255.1
+       no bgp default ipv4-unicast
+       distance bgp 20 200 200
+       maximum-paths 4 ecmp 4
+       neighbor EVPN-OVERLAY-PEERS peer group
+       neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+       neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+       neighbor EVPN-OVERLAY-PEERS bfd
+       neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+       neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+       neighbor EVPN-OVERLAY-PEERS send-community
+       neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+       neighbor IPv4-UNDERLAY-PEERS peer group
+       neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+       neighbor IPv4-UNDERLAY-PEERS send-community
+       neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+       neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
+       neighbor 172.31.255.1 remote-as 65101
+       neighbor 172.31.255.1 description om-pe11_Ethernet1
+       neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
+       neighbor 172.31.255.5 remote-as 65102
+       neighbor 172.31.255.5 description om-pe12_Ethernet1
+       neighbor 172.31.255.9 peer group IPv4-UNDERLAY-PEERS
+       neighbor 172.31.255.9 remote-as 65103
+       neighbor 172.31.255.9 description om-pe21_Ethernet1
+       neighbor 172.31.255.13 peer group IPv4-UNDERLAY-PEERS
+       neighbor 172.31.255.13 remote-as 65104
+       neighbor 172.31.255.13 description om-pe22_Ethernet1
+       neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+       neighbor 192.168.255.3 remote-as 65101
+       neighbor 192.168.255.3 description om-pe11_Loopback0
+       neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
+       neighbor 192.168.255.4 remote-as 65102
+       neighbor 192.168.255.4 description om-pe12_Loopback0
+       neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
+       neighbor 192.168.255.5 remote-as 65103
+       neighbor 192.168.255.5 description om-pe21_Loopback0
+       neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS
+       neighbor 192.168.255.6 remote-as 65104
+       neighbor 192.168.255.6 description om-pe22_Loopback0
+       redistribute connected route-map RM-CONN-2-BGP
+       !
+       address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+       !
+       address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+       !
+       address-family rt-membership
+      neighbor EVPN-OVERLAY-PEERS activate
+      neighbor EVPN-OVERLAY-PEERS default-route-target only
+    !
+    end
+    ```
+
+### **Full leaf configuration**
+
+??? details "Complete `pe11` running configuration as rendered by AVD"
+
+    ```
+    !
+    no enable password
+    no aaa root
+    !
+    username arista privilege 15 role network-admin secret sha512 $6$7t1sx38LSYabjfkz$TNsa1HyVX4kehVvqFvJVF1omlYKxUkeAV4AfDlJ3tQnSoR1GfaaaicGyKjVJG/s63wxiTW1zgbchOH2dZ38lH.
+    !
+    vlan internal order ascending range 1006 1199
+    !
+    transceiver qsfp default-mode 4x10G
+    !
+    service routing protocols model multi-agent
+    !
+    hostname om-pe11
+    ip name-server vrf MGMT 1.1.1.1
+    ip name-server vrf MGMT 8.8.8.8
+    !
+    spanning-tree mode mstp
+    spanning-tree mst 0 priority 4096
+    !
+    vlan 110
+       name Tenant_A_OP_Zone_1
+    !
+    vlan 111
+       name Tenant_A_OP_Zone_2
+    !
+    vrf instance MGMT
+    !
+    management api http-commands
+       protocol https
+       protocol https ssl profile eAPI
+       no shutdown
+       !
+       vrf MGMT
+          no shutdown
+    !
+    management api gnmi
+       transport grpc default
+          notification timestamp send-time
+       !
+       transport grpc MGMT
+          vrf MGMT
+          notification timestamp send-time
+       provider eos-native
+    !
+    management security
+       !
+       ssl profile eAPI
+          cipher-list HIGH:!eNULL:!aNULL:!MD5:!ADH:!ANULL
+          certificate eAPI.crt key eAPI.key
+    !
+    interface Port-Channel3
+       description PortChannel3
+       no shutdown
+       switchport trunk allowed vlan 110
+       switchport mode trunk
+       switchport
+       !
+       evpn ethernet-segment
+          identifier 0000:0000:0101:0102:0033
+          route-target import 01:01:01:02:00:33
+       lacp system-id 0101.0102.0033
+       spanning-tree portfast
+    !
+    interface Port-Channel4
+       description PortChannel4
+       no shutdown
+       switchport trunk allowed vlan 111
+       switchport mode trunk
+       switchport
+       !
+       evpn ethernet-segment
+          identifier 0000:0000:0101:0102:0044
+          route-target import 01:01:01:02:00:44
+       lacp system-id 0101.0102.0044
+       spanning-tree portfast
+    !
+    interface Ethernet1
+       description P2P_om-spine1_Ethernet1
+       no shutdown
+       mtu 9214
+       no switchport
+       ip address 172.31.255.1/31
+    !
+    interface Ethernet2
+       description P2P_om-spine2_Ethernet1
+       no shutdown
+       mtu 9214
+       no switchport
+       ip address 172.31.255.3/31
+    !
+    interface Ethernet3
+       description SERVER_server01_Eth1
+       no shutdown
+       channel-group 3 mode active
+    !
+    interface Ethernet4
+       description SERVER_server02_Eth1
+       no shutdown
+       channel-group 4 mode active
+    !
+    interface Loopback0
+       description ROUTER_ID
+       no shutdown
+       ip address 192.168.255.3/32
+    !
+    interface Loopback1
+       description VXLAN_TUNNEL_SOURCE
+       no shutdown
+       ip address 192.168.254.3/32
+    !
+    interface Management0
+       description OOB_MANAGEMENT
+       no shutdown
+       vrf MGMT
+       ip address 172.144.100.4/24
+    !
+    interface Vxlan1
+       description om-pe11_VTEP
+       vxlan source-interface Loopback1
+       vxlan udp-port 4789
+       vxlan vlan 110 vni 10110
+       vxlan vlan 111 vni 10111
+    !
+    ip routing
+    no ip routing vrf MGMT
+    !
+    ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+       seq 10 permit 192.168.255.0/24 eq 32
+       seq 20 permit 192.168.254.0/24 eq 32
+    !
+    ip route vrf MGMT 0.0.0.0/0 172.144.100.1
+    !
+    ntp server vrf MGMT time.google.com prefer
+    !
+    route-map RM-CONN-2-BGP permit 10
+       match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+    !
+    router bfd
+       multihop interval 300 min-rx 300 multiplier 3
+    !
+    router bgp 65101
+       router-id 192.168.255.3
+       no bgp default ipv4-unicast
+       distance bgp 20 200 200
+       maximum-paths 4 ecmp 4
+       neighbor EVPN-OVERLAY-PEERS peer group
+       neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+       neighbor EVPN-OVERLAY-PEERS bfd
+       neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+       neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+       neighbor EVPN-OVERLAY-PEERS send-community
+       neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+       neighbor IPv4-UNDERLAY-PEERS peer group
+       neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+       neighbor IPv4-UNDERLAY-PEERS send-community
+       neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+       neighbor 172.31.255.0 peer group IPv4-UNDERLAY-PEERS
+       neighbor 172.31.255.0 remote-as 65001
+       neighbor 172.31.255.0 description om-spine1_Ethernet1
+       neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS
+       neighbor 172.31.255.2 remote-as 65001
+       neighbor 172.31.255.2 description om-spine2_Ethernet1
+       neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+       neighbor 192.168.255.1 remote-as 65001
+       neighbor 192.168.255.1 description om-spine1_Loopback0
+       neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+       neighbor 192.168.255.2 remote-as 65001
+       neighbor 192.168.255.2 description om-spine2_Loopback0
+       redistribute connected route-map RM-CONN-2-BGP
+       !
+       vlan 110
+          rd 192.168.255.3:10110
+          route-target both 10110:10110
+          redistribute learned
+       !
+       vlan 111
+          rd 192.168.255.3:10111
+          route-target both 10111:10111
+          redistribute learned
+       !
+       address-family evpn
+          neighbor EVPN-OVERLAY-PEERS activate
+       !
+       address-family ipv4
+          no neighbor EVPN-OVERLAY-PEERS activate
+          neighbor IPv4-UNDERLAY-PEERS activate
+       !
+       address-family rt-membership
+          neighbor EVPN-OVERLAY-PEERS activate
+    !
+    end
+    ```
+
+### **Full gNMIc configuration**
+
+??? details "Complete `clab/gnmic.yml`"
+
+    ```yaml
+    username: arista
+    password: arista
+    port: 6030
+    timeout: 10s
+    skip-verify: true
+    encoding: json_ietf
+
+    targets:
+      spine1:
+        insecure: true
+      spine2:
+        insecure: true
+      pe11:
+        insecure: true
+      pe12:
+        insecure: true
+      pe21:
+        insecure: true
+      pe22:
+        insecure: true
+
+    subscriptions:
+      bgp_neighbors:
+        paths:
+          - /network-instances/network-instance[name=default]/protocols/protocol[name=BGP]/bgp/neighbors
+        mode: stream
+        stream-mode: sample
+        sample-interval: 5s
+
+      cpu:
+        paths:
+          - components/component/cpu
+        mode: stream
+        stream-mode: sample
+        sample-interval: 5s
+
+      cpu_load_avg:
+        paths:
+          - eos_native:/Kernel/sysinfo
+        mode: stream
+        stream-mode: sample
+        sample-interval: 5s
+
+      processes:
+        paths:
+          - system/processes/process/state
+        mode: stream
+        stream-mode: sample
+        sample-interval: 15s
+
+      memory:
+        paths:
+          - components/component/state/memory/
+          - system/memory/kernel/state
+          - system/memory/state
+        mode: stream
+        stream-mode: sample
+        sample-interval: 5s
+
+      intf_ctrs:
+        paths:
+          - /interfaces/interface[name=*]/state/counters
+        mode: stream
+        stream-mode: sample
+        sample-interval: 5s
+
+      intf_admin_state:
+        paths:
+          - /interfaces/interface[name=*]/state/admin-status
+        mode: stream
+        stream-mode: sample
+        sample-interval: 5s
+
+      intf_oper_state:
+        paths:
+          - /interfaces/interface[name=*]/state/oper-status
+        mode: stream
+        stream-mode: sample
+        sample-interval: 5s
+
+      intf_config:
+        paths:
+          - interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/config
+        mode: stream
+        stream-mode: sample
+        sample-interval: 5s
+
+      show_ver:
+        paths:
+        - eos_native:/Eos/image
+        mode: stream
+        stream-mode: sample
+        sample-interval: 60s
+
+      boot_time:
+        paths:
+        - system/state/boot-time
+        mode: stream
+        stream-mode: sample
+        sample-interval: 60s
+
+      hardware:
+        paths:
+        - components/component/state
+        - eos_native:/Sysdb/hardware/entmib
+        mode: stream
+        stream-mode: sample
+        sample-interval: 60s
+
+      isis_adjacencies:
+        paths:
+          - /network-instances/network-instance[name=default]/protocols/protocol[name=EVPN_UNDERLAY]/isis
+        mode: stream
+        stream-mode: sample
+        sample-interval: 10s
+
+      mac_table:
+        paths:
+          - network-instances/network-instance[name=default]/fdb/mac-table/entries/entry
+        mode: stream
+        stream-mode: sample
+        sample-interval: 30s
+
+      arp:
+        paths:
+          - /interfaces/interface/subinterfaces/subinterface/ipv4/neighbors/neighbor
+        mode: stream
+        stream-mode: sample
+        sample-interval: 30s
+
+      vlan_internal:
+        paths:
+          - eos_native:/Sysdb/bridging/config/vlanConfig
+        mode: stream
+        stream-mode: sample
+        sample-interval: 30s
+
+      conn_mon:
+        paths:
+          - arista/connectivity-monitor/clients/client
+        mode: stream
+        stream-mode: sample
+        sample-interval: 10s
+
+    outputs:
+      prom:
+        type: prometheus
+        listen: :9273
+        path: /metrics
+        metric-prefix: gnmic
+        append-subscription-name: true
+        strings-as-labels: true
+        export-timestamps: true
+        debug: false
+        event-processors:
+          - extract-vlan-id
+          - drop-gr
+          - trim-prefixes
+          - bounce-map
+          - eos-version
+
+    processors:
+      extract-vlan-id:
+        event-extract-tags:
+          value-names:
+            - ".*vlanConfig/(?P<vlan_id>\\d+)/.*"
+      eos-version:
+        event-strings:
+          value-names:
+            - ".*version$"
+            - ".*arch$"
+          transforms:
+            - replace:
+                apply-on: "value"
+                old: "EOS"
+                new: "eos"
+      trim-prefixes:
+        event-strings:
+          value-names:
+            - ".*"
+          transforms:
+            - path-base:
+                apply-on: "name"
+      bounce-map:
+        event-strings:
+          value-names:
+            - oper-status
+            - admin-status
+          transforms:
+            - replace:
+                apply-on: "value"
+                old: "UP"
+                new: "1"
+            - replace:
+                apply-on: "value"
+                old: "DOWN"
+                new: "0"
+      drop-gr:
+        event-delete:
+          value-names:
+            - ".*graceful-restart.*"
+    ```
+
+### **Full Prometheus configuration**
+
+??? details "Complete `clab/prometheus/prometheus.yml`"
+
+    ```yaml
+    global:
+      scrape_interval: 5s
+
+    scrape_configs:
+      - job_name: "gnmic"
+        static_configs:
+          - targets: ["gnmic:9273"]
+    ```
+
+### **Abbreviations glossary**
+
+Terms used throughout this guide. All are also rendered as hover-tooltips inline (via `<abbr>`).
+
+| Term | Expansion |
+|---|---|
+| AFI | Address Family Identifier |
+| AVD | Arista Validated Designs |
+| BFD | Bidirectional Forwarding Detection |
+| BGP | Border Gateway Protocol |
+| ESI | Ethernet Segment Identifier |
+| EVPN | Ethernet VPN (RFC 7432, RFC 8365) |
+| gNMI | gRPC Network Management Interface |
+| gRPC | Google RPC |
+| IRB | Integrated Routing and Bridging |
+| L2VNI | Layer 2 VXLAN Network Identifier |
+| LACP | Link Aggregation Control Protocol |
+| MLAG | Multi-Chassis Link Aggregation |
+| MST | Multiple Spanning Tree |
+| MTU | Maximum Transmission Unit |
+| POD | Point of Delivery |
+| PromQL | Prometheus Query Language |
+| RD | Route Distinguisher |
+| RPC | Remote Procedure Call |
+| RT | Route Target |
+| SAFI | Subsequent Address Family Identifier |
+| TSDB | Time-Series Database |
+| VNI | VXLAN Network Identifier |
+| VRF | Virtual Routing and Forwarding |
+| VTEP | VXLAN Tunnel Endpoint |
+| VXLAN | Virtual eXtensible LAN |
+| YANG | Yet Another Next Generation (RFC 7950 modeling language) |
+
+
+*[BGP]: Border Gateway Protocol
+*[EVPN]: Ethernet VPN (RFC7432, RFC8365)
+*[VXLAN]: Virtual eXtensible LAN
+*[VNI]: VXLAN Network Identifier
+*[L2VNI]: Layer 2 VXLAN Network Identifier
+*[VTEP]: VXLAN Tunnel Endpoint
+*[ESI]: Ethernet Segment Identifier
+*[IRB]: Integrated Routing and Bridging
+*[VRF]: Virtual Routing and Forwarding
+*[gNMI]: gRPC Network Management Interface
+*[gRPC]: Google RPC
+*[YANG]: Yet Another Next Generation (RFC 7950 modeling language)
+*[PromQL]: Prometheus Query Language
+*[TSDB]: Time-Series Database
+*[AVD]: Arista Validated Designs
+*[MLAG]: Multi-Chassis Link Aggregation
+*[LACP]: Link Aggregation Control Protocol
+*[MST]: Multiple Spanning Tree
+*[RPC]: Remote Procedure Call
+*[RD]: Route Distinguisher
+*[RT]: Route Target
+*[AFI]: Address Family Identifier
+*[SAFI]: Subsequent Address Family Identifier
+*[BFD]: Bidirectional Forwarding Detection
+*[POD]: Point of Delivery
+*[MTU]: Maximum Transmission Unit

--- a/docs/gnmic-deployment-guide/telemetry-stack.md
+++ b/docs/gnmic-deployment-guide/telemetry-stack.md
@@ -207,29 +207,4 @@ Dashboards are read from `clab/grafana/provisioning/dashboards/` on container st
 
 **Previous:** [← Fabric Configuration](fabric-configuration.md) &nbsp;·&nbsp; **Next:** [Exploring the Lab →](exploring-the-lab.md) &nbsp;·&nbsp; [Back to guide index](index.md)
 
-*[BGP]: Border Gateway Protocol
-*[EVPN]: Ethernet VPN (RFC7432, RFC8365)
-*[VXLAN]: Virtual eXtensible LAN
-*[VNI]: VXLAN Network Identifier
-*[L2VNI]: Layer 2 VXLAN Network Identifier
-*[VTEP]: VXLAN Tunnel Endpoint
-*[ESI]: Ethernet Segment Identifier
-*[IRB]: Integrated Routing and Bridging
-*[VRF]: Virtual Routing and Forwarding
-*[gNMI]: gRPC Network Management Interface
-*[gRPC]: Google RPC
-*[YANG]: Yet Another Next Generation (RFC 7950 modeling language)
-*[PromQL]: Prometheus Query Language
-*[TSDB]: Time-Series Database
-*[AVD]: Arista Validated Designs
-*[MLAG]: Multi-Chassis Link Aggregation
-*[LACP]: Link Aggregation Control Protocol
-*[MST]: Multiple Spanning Tree
-*[RPC]: Remote Procedure Call
-*[RD]: Route Distinguisher
-*[RT]: Route Target
-*[AFI]: Address Family Identifier
-*[SAFI]: Subsequent Address Family Identifier
-*[BFD]: Bidirectional Forwarding Detection
-*[POD]: Point of Delivery
-*[MTU]: Maximum Transmission Unit
+--8<-- "gnmic-deployment-guide/_abbreviations.md"

--- a/docs/gnmic-deployment-guide/telemetry-stack.md
+++ b/docs/gnmic-deployment-guide/telemetry-stack.md
@@ -1,0 +1,235 @@
+# **Telemetry Stack**
+
+The three telemetry containers — `gnmic`, `prometheus`, `grafana` — share the lab's management network and form a linear pipeline. gNMIc subscribes to switches over gRPC on port 6030 and exposes reshaped metrics at `:9273/metrics`. Prometheus scrapes that endpoint every 5 seconds. Grafana queries Prometheus via PromQL for the pre-provisioned dashboards.
+
+## **gNMIc Collector**
+
+The gNMIc collector runs as a Linux container (`ghcr.io/openconfig/gnmic:latest`) on the management network at `172.144.100.200`. Its entire configuration is `clab/gnmic.yml`, mounted at `/gnmic.yml`. It follows the standard gNMI *dial-in* model — the collector initiates the gRPC connection to each switch, sends a `SubscribeRequest`, and receives updates on the long-lived stream.
+
+![gNMI dial-in flow](../assets/img/gnmic-pg-dial-in.svg)
+
+### **Targets (gNMIc)**
+
+Every leaf and spine is enumerated. The switches present self-signed gRPC certs; `insecure: true` disables verification for the lab.
+
+```yaml
+username: arista
+password: arista
+port: 6030
+timeout: 10s
+skip-verify: true
+encoding: json_ietf
+
+targets:
+  spine1:
+    insecure: true
+  spine2:
+    insecure: true
+  pe11:
+    insecure: true
+  pe12:
+    insecure: true
+  pe21:
+    insecure: true
+  pe22:
+    insecure: true
+```
+
+### **Subscriptions (gNMIc)**
+
+17 subscriptions in total; each with an explicit `stream-mode` and `sample-interval`. Frequently-changing operational counters run at 5s; slower-moving inventory (hardware, boot-time, EOS image) at 60s. The complete list is in [Lab Environment → Telemetry subscriptions catalog](index.md#telemetry-subscriptions-catalog); a representative extract:
+
+```yaml
+subscriptions:
+  bgp_neighbors:
+    paths:
+      - /network-instances/network-instance[name=default]/protocols/protocol[name=BGP]/bgp/neighbors
+    mode: stream
+    stream-mode: sample
+    sample-interval: 5s
+
+  intf_ctrs:
+    paths:
+      - /interfaces/interface[name=*]/state/counters
+    mode: stream
+    stream-mode: sample
+    sample-interval: 5s
+
+  intf_oper_state:
+    paths:
+      - /interfaces/interface[name=*]/state/oper-status
+    mode: stream
+    stream-mode: sample
+    sample-interval: 5s
+
+  isis_adjacencies:
+    paths:
+      - /network-instances/network-instance[name=default]/protocols/protocol[name=EVPN_UNDERLAY]/isis
+    mode: stream
+    stream-mode: sample
+    sample-interval: 10s
+
+  cpu_load_avg:
+    paths:
+      - eos_native:/Kernel/sysinfo
+    mode: stream
+    stream-mode: sample
+    sample-interval: 5s
+```
+
+!!! note
+    The `isis_adjacencies` subscription only returns data when the fabric was deployed with `-e underlay_routing_protocol=isis`. In the default eBGP-underlay build it silently returns nothing.
+
+### **Event Processors (gNMIc)**
+
+Prometheus requires numeric samples and cardinality-bounded labels. gNMIc's event processors run in sequence on each notification before it is exported. Five processors are wired into the `prom` output:
+
+```yaml
+processors:
+  extract-vlan-id:
+    event-extract-tags:
+      value-names:
+        - ".*vlanConfig/(?P<vlan_id>\\d+)/.*"
+  eos-version:
+    event-strings:
+      value-names:
+        - ".*version$"
+        - ".*arch$"
+      transforms:
+        - replace:
+            apply-on: "value"
+            old: "EOS"
+            new: "eos"
+  trim-prefixes:
+    event-strings:
+      value-names:
+        - ".*"
+      transforms:
+        - path-base:
+            apply-on: "name"
+  bounce-map:
+    event-strings:
+      value-names:
+        - oper-status
+        - admin-status
+      transforms:
+        - replace:
+            apply-on: "value"
+            old: "UP"
+            new: "1"
+        - replace:
+            apply-on: "value"
+            old: "DOWN"
+            new: "0"
+  drop-gr:
+    event-delete:
+      value-names:
+        - ".*graceful-restart.*"
+```
+
+- `extract-vlan-id` promotes a VLAN id out of the path and into a Prometheus label so PromQL can group by VLAN.
+- `eos-version` normalises the version string.
+- `trim-prefixes` shortens the metric name to the leaf (`state/oper-status` → `oper_status`).
+- `bounce-map` converts enum strings `UP`/`DOWN` to `1`/`0` so `oper-status` is queryable as a numeric time-series.
+- `drop-gr` removes any leaf containing `graceful-restart` before `trim-prefixes` runs — otherwise multiple sibling `graceful-restart.*` leaves would collide on the same trimmed name and overwrite the `pfxRcd` counters with `0`.
+
+### **Prometheus Output (gNMIc)**
+
+```yaml
+outputs:
+  prom:
+    type: prometheus
+    listen: :9273
+    path: /metrics
+    metric-prefix: gnmic
+    append-subscription-name: true
+    strings-as-labels: true
+    export-timestamps: true
+    debug: false
+    event-processors:
+      - extract-vlan-id
+      - drop-gr
+      - trim-prefixes
+      - bounce-map
+      - eos-version
+```
+
+`append-subscription-name: true` gives every metric a `_subscription_name_` label so you can filter by which subscription produced it (e.g. `bgp_neighbors` vs `intf_oper_state`). `strings-as-labels: true` turns non-numeric leaves into labels rather than dropping them. Port 9273 is exposed inside the container network only — it is not published to the host.
+
+## **Prometheus**
+
+Time-series database. Scrapes gNMIc every 5 seconds, stores samples locally, serves PromQL queries to Grafana. UI at `http://<host>:9090`.
+
+### **Scrape Configuration**
+
+Prometheus scrapes the gNMIc `/metrics` endpoint every 5s. Only one target is configured; gNMIc itself fans out to all six switches.
+
+```yaml
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: "gnmic"
+    static_configs:
+      - targets: ["gnmic:9273"]
+```
+
+Prometheus runs as `prom/prometheus:v2.54.1` at `172.144.100.210`. Its UI is published to the host at `http://<host>:9090`.
+
+### **Retention & Storage**
+
+Default retention (15 days) and default TSDB path (`/prometheus`). The container is not backed by a persistent volume — restarting the lab clears the store, which is intentional for a lab environment.
+
+## **Grafana**
+
+Visualization layer. Runs as `grafana/grafana:11.2.0` at `172.144.100.220`, published to the host at `http://<host>:3001`. Anonymous Admin access is enabled so users can explore dashboards without logging in; the `arista/arista` credentials are honoured for panel editing.
+
+### **Datasource Provisioning**
+
+A single Prometheus datasource is provisioned from `clab/grafana/provisioning/datasources/`, pointing at `http://prometheus:9090`.
+
+### **Dashboard Provisioning**
+
+Dashboards are read from `clab/grafana/provisioning/dashboards/` on container start; the JSON files are the source of truth. Changes made in the Grafana UI live only until the container is restarted.
+
+### **Dashboards Included**
+
+| Dashboard | Focus | Key Metrics |
+|---|---|---|
+| `device-overview` | Per-device roll-up | CPU, memory, uptime, EOS version, interface count |
+| `fabric-health` | Fabric-wide traffic light | BGP session states, interface admin/oper counts |
+| `interface-stats` | Interface counters over time | `in-octets`/`out-octets`, errors, discards |
+| `l3-telemetry` | Underlay + overlay routing | BGP received/installed prefixes per neighbor, IS-IS adjacency counts |
+| `evpn-telemetry` | EVPN overlay | L2VPN-EVPN peer count/state, prefixes-installed, rejected routes, overlay peer flap count |
+
+
+---
+
+**Previous:** [← Fabric Configuration](fabric-configuration.md) &nbsp;·&nbsp; **Next:** [Exploring the Lab →](exploring-the-lab.md) &nbsp;·&nbsp; [Back to guide index](index.md)
+
+*[BGP]: Border Gateway Protocol
+*[EVPN]: Ethernet VPN (RFC7432, RFC8365)
+*[VXLAN]: Virtual eXtensible LAN
+*[VNI]: VXLAN Network Identifier
+*[L2VNI]: Layer 2 VXLAN Network Identifier
+*[VTEP]: VXLAN Tunnel Endpoint
+*[ESI]: Ethernet Segment Identifier
+*[IRB]: Integrated Routing and Bridging
+*[VRF]: Virtual Routing and Forwarding
+*[gNMI]: gRPC Network Management Interface
+*[gRPC]: Google RPC
+*[YANG]: Yet Another Next Generation (RFC 7950 modeling language)
+*[PromQL]: Prometheus Query Language
+*[TSDB]: Time-Series Database
+*[AVD]: Arista Validated Designs
+*[MLAG]: Multi-Chassis Link Aggregation
+*[LACP]: Link Aggregation Control Protocol
+*[MST]: Multiple Spanning Tree
+*[RPC]: Remote Procedure Call
+*[RD]: Route Distinguisher
+*[RT]: Route Target
+*[AFI]: Address Family Identifier
+*[SAFI]: Subsequent Address Family Identifier
+*[BFD]: Bidirectional Forwarding Detection
+*[POD]: Point of Delivery
+*[MTU]: Maximum Transmission Unit

--- a/docs/gnmic-deployment-guide/troubleshooting.md
+++ b/docs/gnmic-deployment-guide/troubleshooting.md
@@ -47,29 +47,4 @@ Capabilities lists model *support* — not every model is *populated*. For AFT s
 
 **Previous:** [← Exploring the Lab](exploring-the-lab.md) &nbsp;·&nbsp; [Back to guide index](index.md)
 
-*[BGP]: Border Gateway Protocol
-*[EVPN]: Ethernet VPN (RFC7432, RFC8365)
-*[VXLAN]: Virtual eXtensible LAN
-*[VNI]: VXLAN Network Identifier
-*[L2VNI]: Layer 2 VXLAN Network Identifier
-*[VTEP]: VXLAN Tunnel Endpoint
-*[ESI]: Ethernet Segment Identifier
-*[IRB]: Integrated Routing and Bridging
-*[VRF]: Virtual Routing and Forwarding
-*[gNMI]: gRPC Network Management Interface
-*[gRPC]: Google RPC
-*[YANG]: Yet Another Next Generation (RFC 7950 modeling language)
-*[PromQL]: Prometheus Query Language
-*[TSDB]: Time-Series Database
-*[AVD]: Arista Validated Designs
-*[MLAG]: Multi-Chassis Link Aggregation
-*[LACP]: Link Aggregation Control Protocol
-*[MST]: Multiple Spanning Tree
-*[RPC]: Remote Procedure Call
-*[RD]: Route Distinguisher
-*[RT]: Route Target
-*[AFI]: Address Family Identifier
-*[SAFI]: Subsequent Address Family Identifier
-*[BFD]: Bidirectional Forwarding Detection
-*[POD]: Point of Delivery
-*[MTU]: Maximum Transmission Unit
+--8<-- "gnmic-deployment-guide/_abbreviations.md"

--- a/docs/gnmic-deployment-guide/troubleshooting.md
+++ b/docs/gnmic-deployment-guide/troubleshooting.md
@@ -1,0 +1,75 @@
+# **Troubleshooting**
+
+Every layer of the pipeline has a distinct check. Work them in order and the fault is found fast.
+
+## **The dashboard is empty, lagging, or wrong**
+
+Walk backwards from Grafana to the switch. First hop to fail tells you where the bug is.
+
+1. **Grafana.** Does the panel query return data in Prometheus' **Explore** tab? If yes, the bug is in Grafana (query syntax, time range, template variable). If no →
+2. **Prometheus.** Does `up{job="gnmic"} == 1` hold? If not, Prometheus can't reach gnmic — check `docker logs prometheus`. If yes →
+3. **gnmic `/metrics`.** `docker exec gnmic wget -qO- localhost:9273/metrics | grep <metric>` — is the metric present? If not, either the subscription isn't running or a processor dropped/renamed it. Check `docker logs gnmic`. If yes →
+4. **gnmic subscription to the switch.** `G -a <switch>:6030 get --path <path>` — does the switch return data on that path directly? If not, the switch isn't populating it (wrong path, feature not enabled, empty subtree).
+
+## **gnmic can't reach a switch**
+
+Isolate by protocol layer:
+
+1. **TCP port.** From the gnmic container: `docker exec gnmic nc -zv <switch> 6030`. `Connection refused` → server or ACL. `Timeout` → routing.
+2. **Server up.** On the switch: `show management api gnmi`. Look for `Enabled: yes` and `Octa: enabled`.
+3. **VRF.** `show management api gnmi transport`. Is the transport in the VRF the collector can reach? This lab reaches switches on the MGMT VRF via `Management0`, so the `MGMT` transport must be `no shutdown`.
+4. **Auth.** `G -a <switch>:6030 capabilities` on the collector. If TCP is fine but capabilities fails, it's auth (username/password) or TLS.
+
+## **A subscription is running but no data lands in Prometheus**
+
+Two common causes:
+
+- **Path is valid but empty on this platform.** `G -a <switch>:6030 get --path <path>` returns `{}` with no error. The path exists in YANG but the switch has nothing to say about it (feature not configured, no ARP entries yet, `eos_native:` origin blocked). Confirm the path is populated with `Get` before assuming the subscription is broken.
+- **A processor dropped or renamed the metric.** Check the `event-processors:` chain in `clab/gnmic.yml`. Grep the `/metrics` endpoint for any variation of the leaf name — you may find it under an unexpected metric name after `trim-prefixes` ran.
+
+## **Set failed, but the leaf I'm changing looks fine**
+
+gNMI `Set` validates the *whole* config transaction, not just the leaves you touched. An unrelated inconsistency elsewhere (e.g. BGP `redistribute static` with no static routes) can fail an innocent interface-description Set. Read the error message — it usually names the offending path.
+
+## **eos_native paths return empty**
+
+The switch is missing `provider eos-native` under `management api gnmi`. Verify with `show management api gnmi` — you should see `Native: enabled`. Without it, any subscription with an `eos_native:` prefix silently returns nothing.
+
+## **openconfig-igmp / openconfig-aft is advertised in Capabilities but returns empty**
+
+Capabilities lists model *support* — not every model is *populated*. For AFT specifically, you need `provider aft` under `management api models`, and the OpenConfig/Octa agent must be restarted (`agent Octa terminate`) after the config change. Verify the mount worked by querying the `afts/state-synced/state` leaves — `ipv4-unicast: true` / `ipv6-unicast: true` proves AFT is feeding.
+
+
+
+
+
+---
+
+**Previous:** [← Exploring the Lab](exploring-the-lab.md) &nbsp;·&nbsp; [Back to guide index](index.md)
+
+*[BGP]: Border Gateway Protocol
+*[EVPN]: Ethernet VPN (RFC7432, RFC8365)
+*[VXLAN]: Virtual eXtensible LAN
+*[VNI]: VXLAN Network Identifier
+*[L2VNI]: Layer 2 VXLAN Network Identifier
+*[VTEP]: VXLAN Tunnel Endpoint
+*[ESI]: Ethernet Segment Identifier
+*[IRB]: Integrated Routing and Bridging
+*[VRF]: Virtual Routing and Forwarding
+*[gNMI]: gRPC Network Management Interface
+*[gRPC]: Google RPC
+*[YANG]: Yet Another Next Generation (RFC 7950 modeling language)
+*[PromQL]: Prometheus Query Language
+*[TSDB]: Time-Series Database
+*[AVD]: Arista Validated Designs
+*[MLAG]: Multi-Chassis Link Aggregation
+*[LACP]: Link Aggregation Control Protocol
+*[MST]: Multiple Spanning Tree
+*[RPC]: Remote Procedure Call
+*[RD]: Route Distinguisher
+*[RT]: Route Target
+*[AFI]: Address Family Identifier
+*[SAFI]: Subsequent Address Family Identifier
+*[BFD]: Bidirectional Forwarding Detection
+*[POD]: Point of Delivery
+*[MTU]: Maximum Transmission Unit

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,5 +1,11 @@
 # Telemetry labs
 
+!!! tip "New: Deployment Guide"
+
+    A full deployment guide for this lab is now available — covering the fabric design, gNMIc collector configuration, event processors, dashboards, and hands-on RPC/stream-mode walkthroughs.
+
+    [Open the Deployment Guide :octicons-book-16:](gnmic-deployment-guide/index.md){ .md-button .md-button--primary }
+
 ## gNMIc Prometheus Grafana Lab
 
 !!! Info "Lab Details"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,9 @@ markdown_extensions:
   - admonition
   - footnotes
   - pymdownx.details
+  - pymdownx.snippets:
+      base_path: [docs]
+      check_paths: true
   - pymdownx.superfences
   - pymdownx.critic
   - pymdownx.caret

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,18 +51,21 @@ theme:
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      accent: red
+      primary: blue
+      accent: blue
       toggle:
         icon: material/weather-sunny
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      accent: amber
+      primary: blue
+      accent: light blue
       toggle:
         icon: material/weather-night
         name: Switch to light mode
 
 markdown_extensions:
+  - abbr
   - attr_list
   - admonition
   - footnotes
@@ -140,4 +143,10 @@ nav:
   - ATD Labs:
       - ATD Dual DC: atd-atd-dual-dc.md
   - Telemetry:
-      gNMIc Prometheus Grafana Lab: telemetry.md
+      - gNMIc Prometheus Grafana Lab: telemetry.md
+      - Deployment Guide:
+          - gnmic-deployment-guide/index.md
+          - Fabric Configuration: gnmic-deployment-guide/fabric-configuration.md
+          - Telemetry Stack: gnmic-deployment-guide/telemetry-stack.md
+          - Exploring the Lab: gnmic-deployment-guide/exploring-the-lab.md
+          - Troubleshooting: gnmic-deployment-guide/troubleshooting.md


### PR DESCRIPTION
## Change Summary

Adds a multi-page deployment guide for the existing `gnmic-prometheus-grafana` lab under `docs/gnmic-deployment-guide/`, linked from `docs/telemetry.md` via a "New: Deployment Guide" tip callout.

Five pages, aligned with the tech-library deployment-guide shape:

- **index** — landing / overview / lab environment / appendix
- **fabric-configuration** — spine + leaf snippets, plus an IS-IS underlay variant matching `-e underlay_routing_protocol=isis`
- **telemetry-stack** — gNMIc / Prometheus / Grafana config and event processors
- **exploring-the-lab** — pipeline-aligned exercises: gNMI Read, Subscribe & Stream Modes (ONCE, SAMPLE, ON_CHANGE, TARGET_DEFINED, mixed-mode), gNMI Write, collector configuration, metrics in Prometheus, Grafana panels
- **troubleshooting** — common failure modes

Also enables `pymdownx.snippets` and adds a shared `_abbreviations.md` so the acronym block isn't duplicated across pages (and doesn't leak as raw text on GitHub's blob view).

Six new SVGs under `docs/assets/img/gnmic-pg-*.svg` for topology, underlay, overlay, pipeline, dial-in flow, and stream-mode timing diagrams.

`mkdocs.yml` changes: adds the nav entry under the existing Telemetry group; enables `abbr` and `pymdownx.snippets`; switches palette to blue for consistency with the rest of the site.

## Related Issue(s)

fixes #<ISSUE ID>

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from the upstream `main` branch
